### PR TITLE
hyper-rustls: add ring Rustls backend & use it by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,7 @@ jobs:
     - run: cargo clippy --all-targets --no-default-features
     - run: cargo build --all-targets --features native-tls
     - run: cargo build --all-targets --features rustls-tls
+    - run: cargo build --all-targets --features rustls-tls-aws
     - run: cargo clippy --all-targets --all-features
 
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  MSRV: 1.67.0
+  MSRV: 1.70.0
 
 jobs:
   build:
@@ -32,9 +32,6 @@ jobs:
     - run: rustup toolchain install ${{ env.MSRV }} --profile minimal
     - run: rustup override set ${{ env.MSRV }}
     - run: rustup show active-toolchain -v
-    # cargo from toolchain v1.67 doesn't choose versions based on MSRV,
-    # so we downgrade tokio because since v1.39 it requires rustc >=1.70.
-    - run: cargo update -p tokio --precise 1.38.1
     - run: cargo build
     - run: cargo build --no-default-features
     - run: cargo build --features uuid,time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 # update `derive/Cargo.toml` and CI if changed
-rust-version = "1.67.0"
+rust-version = "1.70.0"
 
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
@@ -58,8 +58,8 @@ uuid = ["dep:uuid"]
 time = ["dep:time"]
 lz4 = ["dep:lz4_flex", "dep:cityhash-rs"]
 native-tls = ["dep:hyper-tls"]
-rustls-tls = ["dep:hyper-rustls", "hyper-rustls?/ring"]
-rustls-tls-aws = ["dep:hyper-rustls", "hyper-rustls?/aws-lc-rs"]
+rustls-tls = ["dep:hyper-rustls", "dep:rustls", "hyper-rustls?/ring"]
+rustls-tls-aws = ["dep:hyper-rustls", "dep:rustls", "hyper-rustls?/aws-lc-rs"]
 
 [dependencies]
 clickhouse-derive = { version = "0.2.0", path = "derive" }
@@ -72,6 +72,7 @@ http-body-util = "0.1.2"
 hyper = "1.4"
 hyper-util = { version = "0.1.6", features = ["client-legacy", "http1"] }
 hyper-tls = { version = "0.6.0", optional = true }
+rustls = { version = "0.23", default-features = false, optional = true }
 hyper-rustls = { version = "0.27.2", default-features = false, features = [
     "http1",
     "http2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ homepage = "https://clickhouse.com"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.67.0" # update `derive/Cargo.toml` and CI if changed
+rust-version = "1.67.0"                                                  # update `derive/Cargo.toml` and CI if changed
 
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
@@ -57,7 +57,8 @@ uuid = ["dep:uuid"]
 time = ["dep:time"]
 lz4 = ["dep:lz4_flex", "dep:cityhash-rs"]
 native-tls = ["dep:hyper-tls"]
-rustls-tls = ["dep:hyper-rustls"]
+rustls-tls = ["dep:hyper-rustls", "hyper-rustls?/ring"]
+rustls-tls-aws = ["dep:hyper-rustls", "hyper-rustls?/aws-lc-rs"]
 
 [dependencies]
 clickhouse-derive = { version = "0.2.0", path = "derive" }
@@ -70,7 +71,13 @@ http-body-util = "0.1.2"
 hyper = "1.4"
 hyper-util = { version = "0.1.6", features = ["client-legacy", "http1"] }
 hyper-tls = { version = "0.6.0", optional = true }
-hyper-rustls = { version = "0.27.2", features = ["webpki-roots"], optional = true }
+hyper-rustls = { version = "0.27.2", default-features = false, features = [
+    "http1",
+    "http2",
+    "native-tokio",
+    "tls12",
+    "webpki-roots",
+], optional = true }
 url = "2.1.1"
 futures = "0.3.5"
 futures-channel = "0.3.30"
@@ -78,7 +85,9 @@ static_assertions = "1.1"
 sealed = "0.5"
 sha-1 = { version = "0.10", optional = true }
 serde_json = { version = "1.0.68", optional = true }
-lz4_flex = { version = "0.11.3", default-features = false, features = ["std"], optional = true }
+lz4_flex = { version = "0.11.3", default-features = false, features = [
+    "std",
+], optional = true }
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ homepage = "https://clickhouse.com"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
-rust-version = "1.67.0"                                                  # update `derive/Cargo.toml` and CI if changed
+# update `derive/Cargo.toml` and CI if changed
+rust-version = "1.67.0"
 
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -7,7 +7,8 @@ repository = "https://github.com/ClickHouse/clickhouse-rs"
 homepage = "https://clickhouse.com"
 edition = "2021"
 license = "MIT OR Apache-2.0"
-rust-version = "1.67.0" # update `Cargo.toml` and CI if changed
+# update `Cargo.toml` and CI if changed
+rust-version = "1.70.0"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -97,10 +97,10 @@ impl Default for Client {
         ))]
         let connector = hyper_tls::HttpsConnector::new_with_connector(connector);
 
-        #[cfg(feature = "rustls-tls")]
+        #[cfg(all(feature = "rustls-tls", not(feature = "rustls-tls-aws")))]
         let connector =
             prepare_hyper_rustls_client(connector, rustls::crypto::ring::default_provider());
-        #[cfg(feature = "rustls-tls-aws")]
+        #[cfg(all(feature = "rustls-tls-aws", not(feature = "rustls-tls")))]
         let connector =
             prepare_hyper_rustls_client(connector, rustls::crypto::aws_lc_rs::default_provider());
 


### PR DESCRIPTION
Recently `rustls` crate switched to the `aws-lc-rs` crypto backend by default (probably because it's FIPS certified) which requires a C compiler to build, which adds unnecessary complexity.

This PR makes `hyper-rustls` use pure Rust `ring` backend by default with an option to use `aws-lc-rs` through `rustls-tls-aws` feature.