### PR TITLE
Fetch rows in JSON format

### DIFF
--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -203,7 +203,7 @@ impl<T> JsonCursor<T> {
                 match serde_json::from_str(workaround_51132(line)) {
                     Ok(JsonRow::Row(value)) => return Ok(Some(value)),
                     Ok(JsonRow::Progress { .. }) => continue,
-                    Err(err) => return Err(Error::BadResponse(err.to_string())),
+                    Err(err) => return Err(Error::BadResponse(format!("{err} in {line:?}"))),
                 }
             }
 

--- a/src/query.rs
+++ b/src/query.rs
@@ -93,6 +93,9 @@ impl Query {
     }
 
     /// Executes the query, returning a [`watch::RowJsonCursor`] to obtain results.
+    ///
+    /// Beware that with `JSONEachRow` format, Clickhouse always returns
+    /// a JSON object in the `{ "column1": value1, "column2": value2 }` format and not as `[value1, value2]`.
     #[cfg(feature = "watch")]
     pub fn fetch_json<T>(mut self) -> Result<watch::RowJsonCursor<T>> {
         self.sql.append(" FORMAT JSONEachRowWithProgress");
@@ -104,6 +107,9 @@ impl Query {
     /// Executes the query and returns just a single row.
     ///
     /// Note that `T` must be owned.
+    ///
+    /// Beware that with `JSONEachRow` format, Clickhouse always returns
+    /// a JSON object in the `{ "column1": value1, "column2": value2 }` format and not as `[value1, value2]`.
     #[cfg(feature = "watch")]
     pub async fn fetch_json_one<T>(self) -> Result<T>
     where
@@ -119,6 +125,9 @@ impl Query {
     /// Executes the query and returns at most one row.
     ///
     /// Note that `T` must be owned.
+    ///
+    /// Beware that with `JSONEachRow` format, Clickhouse always returns
+    /// a JSON object in the `{ "column1": value1, "column2": value2 }` format and not as `[value1, value2]`.
     #[cfg(feature = "watch")]
     pub async fn fetch_json_optional<T>(self) -> Result<Option<T>>
     where
@@ -131,6 +140,9 @@ impl Query {
     /// collected into a [`Vec`].
     ///
     /// Note that `T` must be owned.
+    ///
+    /// Beware that with `JSONEachRow` format, Clickhouse always returns
+    /// a JSON object in the `{ "column1": value1, "column2": value2 }` format and not as `[value1, value2]`.
     #[cfg(feature = "watch")]
     pub async fn fetch_json_all<T>(self) -> Result<Vec<T>>
     where


### PR DESCRIPTION
## Summary

This is a draft PR which adds the support for fetching rows in JSON format.

The current [`Query::fetch`](https://docs.rs/clickhouse/latest/clickhouse/query/struct.Query.html#method.fetch) fetches the results using `FORMAT RowBinary` only which requires a strict 1:1 mapping between the query schema and the deserialized type.
And that has a lot of limitations: 
* #10 
* #101
* #53
* etc

This PR allows the row deserialization into a `T: Deserialize` which eliminates the limitations of `Query::fetch`:

* when the table schema is not known: `SELECT * from ?`
* when the table schema is not specified: `DESCRIBE TABLE ?`
* when we read less columns than we select

## Unresolved questions

* am aware (well, now) of https://github.com/suharev7/clickhouse-rs but while that library lifts some of the limitations, it's very different from this one and I'd rather stick to this in hope that #10 will eventually be supported
* the naming `Query::json`, `Query::json_one`, `Query::json_all` is very unfortunate
  - maybe, `Query::fetch_json`, `Query::fetch_json_one` would be better albeit verbose 
* `Query::json` requires the `watch` feature which is a bit misleading - we can improve this

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
