### PR TITLE
Allow overriding the ? query argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -300,7 +300,12 @@ impl Client {
 
     /// Starts a new SELECT/DDL query.
     pub fn query(&self, query: &str) -> query::Query {
-        query::Query::new(self, query)
+        query::Query::new(self, query, "?")
+    }
+
+    /// Starts a new SELECT/DDL query using the given arg for binding.
+    pub fn query_with_arg(&self, query: &str, arg: &str) -> query::Query {
+        query::Query::new(self, query, arg)
     }
 
     /// Starts a new WATCH query.

--- a/src/query.rs
+++ b/src/query.rs
@@ -23,10 +23,10 @@ pub struct Query {
 }
 
 impl Query {
-    pub(crate) fn new(client: &Client, template: &str) -> Self {
+    pub(crate) fn new(client: &Client, template: &str, arg: &str) -> Self {
         Self {
             client: client.clone(),
-            sql: SqlBuilder::new(template),
+            sql: SqlBuilder::new(template, arg),
         }
     }
 

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -84,7 +84,7 @@ impl Watch<Rows> {
 
         Self {
             client,
-            sql: SqlBuilder::new(template),
+            sql: SqlBuilder::new(template, "?"),
             refresh: None,
             limit: None,
             _kind: Rows,


### PR DESCRIPTION
## Summary
Adds `query_with_arg` that allows using something other than `?` for binding.

Just a simple workaround for #60 that I needed to get unblocked that I thought might be useful to others.

## Checklist
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
