### PR TITLE
Debug Query as SQL string. 

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -1,6 +1,6 @@
 use hyper::{header::CONTENT_LENGTH, Method, Request};
 use serde::Deserialize;
-use std::fmt;
+use std::fmt::Display;
 use url::Url;
 
 use crate::headers::with_request_headers;
@@ -23,18 +23,17 @@ pub struct Query {
     sql: SqlBuilder,
 }
 
-impl fmt::Debug for Query {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{sql}", sql = self.sql)
-    }
-}
-
 impl Query {
     pub(crate) fn new(client: &Client, template: &str) -> Self {
         Self {
             client: client.clone(),
             sql: SqlBuilder::new(template),
         }
+    }
+
+    /// Display SQL query as string.
+    pub fn sql_display(&self) -> &impl Display {
+        &self.sql
     }
 
     /// Binds `value` to the next `?` in the query.

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,6 @@
 use hyper::{header::CONTENT_LENGTH, Method, Request};
 use serde::Deserialize;
+use std::fmt;
 use url::Url;
 
 use crate::headers::with_request_headers;
@@ -20,6 +21,12 @@ const MAX_QUERY_LEN_TO_USE_GET: usize = 8192;
 pub struct Query {
     client: Client,
     sql: SqlBuilder,
+}
+
+impl fmt::Debug for Query {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{sql}", sql = self.sql)
+    }
 }
 
 impl Query {

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -221,7 +221,7 @@ async fn prints_query() {
 
     let q = client.query("SELECT ?fields FROM test WHERE a = ? AND b < ?");
     assert_eq!(
-        format!("{q:?}"),
+        format!("{}", q.sql_display()),
         "SELECT ?fields FROM test WHERE a = ? AND b < ?"
     );
 }

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -214,3 +214,14 @@ async fn overrides_client_options() {
     // should override the client options
     assert_eq!(value, override_value);
 }
+
+#[tokio::test]
+async fn prints_query() {
+    let client = prepare_database!();
+
+    let q = client.query("SELECT ?fields FROM test WHERE a = ? AND b < ?");
+    assert_eq!(
+        format!("{q:?}"),
+        "SELECT ?fields FROM test WHERE a = ? AND b < ?"
+    );
+}


### PR DESCRIPTION
## Summary

Allow to print the current SQL query, whether it's bound or not. Useful for logging and diagnostics.

Note: I chose `Debug` over `Display` because the latter is too implicit and somebody might accidentally pass a query into a string.

Albeit, something like `fn Query::into_string(self) -> String` can be useful on its own - as a poor man's query builder:

```rust
let q = client.query("SELECT id from system.users WHERE name = ?");
let q = q.bind("default");

// store the query string for later 
let query_string = q.into_string(); // returns `q.sql.finish()` inernally

// then execute it:
client.query(&query_string).fetch();
```

closes #146 

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
- [ ] **conflicts** with #154, this PR needs to be rebased on top of that