### PR TITLE
Enforce API documentation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ rust-version = "1.70.0"
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
 unreachable_pub = "warn"
-# TODO: missing_docs = "warn"
+missing_docs = "warn"
 unexpected_cfgs = "allow" # for `docsrs`
 
 [lints.clippy]


### PR DESCRIPTION
## Summary

Currently almost nobody documents added functions which is not good for the users of this library - but the API must have documentation.

Let's warn about missing docs (deny would be even better).
