### PR TITLE
Variant data type support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+
+## [0.13.1] - 2024-10-21
 ### Added
 - query/cursor: add `RowCursor::{decoded_bytes,received_bytes}` methods ([#169]).
 
@@ -357,7 +359,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `Client::query()` for selecting from tables and DDL statements.
 
 <!-- next-url -->
-[Unreleased]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.13.0...HEAD
+[Unreleased]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.13.1...HEAD
+[0.13.1]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.13.0...v0.13.1
 [0.13.0]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.12.2...v0.13.0
 [0.12.2]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.12.1...v0.12.2
 [0.12.1]: https://github.com/ClickHouse/clickhouse-rs/compare/v0.12.0...v0.12.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- next-header -->
 
 ## [Unreleased] - ReleaseDate
+### Added
+- [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant) support.
 
 ## [0.13.1] - 2024-10-21
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ### Added
-- [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant) support.
+- [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant) support ([#170]).
+
+[#170]: https://github.com/ClickHouse/clickhouse-rs/pull/170
 
 ## [0.13.1] - 2024-10-21
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clickhouse"
-version = "0.13.0"
+version = "0.13.1"
 description = "Official Rust client for ClickHouse DB"
 keywords = ["clickhouse", "database", "driver", "tokio", "hyper"]
 authors = ["ClickHouse Contributors", "Paul Loyd <pavelko95@gmail.com>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,10 @@ required-features = ["rustls-tls"]
 name = "data_types_derive_simple"
 required-features = ["time", "uuid"]
 
+[[example]]
+name = "data_types_variant"
+required-features = ["time"]
+
 [profile.release]
 debug = true
 

--- a/README.md
+++ b/README.md
@@ -35,10 +35,10 @@ Note: [ch2rs](https://github.com/ClickHouse/ch2rs) is useful to generate a row t
 To use the crate, add this to your `Cargo.toml`:
 ```toml
 [dependencies]
-clickhouse = "0.13.0"
+clickhouse = "0.13.1"
 
 [dev-dependencies]
-clickhouse = { version = "0.13.0", features = ["test-util"] }
+clickhouse = { version = "0.13.1", features = ["test-util"] }
 ```
 
 <details>

--- a/README.md
+++ b/README.md
@@ -438,13 +438,35 @@ How to choose between all these features? Here are some considerations:
     }
     ```
     </details>
-
-* `JSON`, `Variant`, `Dynamic` types are not supported for now.
+* `Variant` data type is supported as a Rust enum. As the inner Variant types are _always_ sorted alphabetically, Rust enum variants should be defined in the _exactly_ same order as it is in the data type; their names are irrelevant, only the order of the types matters. This following example has a column defined as `Variant(Array(UInt16), Bool, Date, String, UInt32)`:
+    <details>
+    <summary>Example</summary>
+    
+    ```rust,ignore
+    #[derive(Serialize, Deserialize)]
+    enum MyRowVariant {
+        Array(Vec<i16>),
+        Boolean(bool),
+        #[serde(with = "clickhouse::serde::time::date")]
+        Date(time::Date),
+        String(String),
+        UInt32(u32),
+    }
+    
+    #[derive(Row, Serialize, Deserialize)]
+    struct MyRow {
+        id: u64,
+        var: MyRowVariant,
+    }
+    ```
+    </details>
+* `Dynamic` data type is not supported for now.
 
 See also the additional examples:
 
 * [Simpler ClickHouse data types](examples/data_types_derive_simple.rs)
 * [Container-like ClickHouse data types](examples/data_types_derive_containers.rs)
+* [Variant data type](examples/data_types_variant.rs)
 
 ## Mocking
 The crate provides utils for mocking CH server and testing DDL, `SELECT`, `INSERT` and `WATCH` queries.

--- a/examples/README.md
+++ b/examples/README.md
@@ -18,6 +18,7 @@ If something is missing, or you found a mistake in one of these examples, please
 
 - [data_types_derive_simple.rs](data_types_derive_simple.rs) - deriving simpler ClickHouse data types in a struct. Required cargo features: `time`, `uuid`.
 - [data_types_derive_containers.rs](data_types_derive_containers.rs) - deriving container-like (Array, Tuple, Map, Nested, Geo) ClickHouse data types in a struct.
+- [data_types_variant.rs](data_types_variant.rs) - working with the [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant).
 
 ### Special cases
 

--- a/examples/data_types_variant.rs
+++ b/examples/data_types_variant.rs
@@ -1,0 +1,170 @@
+use clickhouse_derive::Row;
+use serde::{Deserialize, Serialize};
+
+use clickhouse::sql::Identifier;
+use clickhouse::{error::Result, Client};
+
+// See also: https://clickhouse.com/docs/en/sql-reference/data-types/variant
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let table_name = "chrs_data_types_variant";
+    let client = Client::default().with_url("http://localhost:8123");
+
+    // No matter the order of the definition on the Variant types in the DDL, this particular Variant will always be sorted as follows:
+    // Variant(Array(UInt16), Bool, FixedString(6), Float32, Float64, Int128, Int16, Int32, Int64, Int8, String, UInt128, UInt16, UInt32, UInt64, UInt8)
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE ?
+            (
+                `id`  UInt64,
+                `var` Variant(
+                          Array(UInt16),
+                          Bool,
+                          Date,
+                          FixedString(6),
+                          Float32, Float64,
+                          Int128, Int16, Int32, Int64, Int8,
+                          String,
+                          UInt128, UInt16, UInt32, UInt64, UInt8
+                      )
+            )
+            ENGINE = MergeTree
+            ORDER BY id",
+        )
+        .bind(Identifier(table_name))
+        .with_option("allow_experimental_variant_type", "1")
+        // This is required only if we are mixing similar types in the Variant definition
+        // In this case, this is various Int/UInt types, Float32/Float64, and String/FixedString
+        // Omit this option if there are no similar types in the definition
+        .with_option("allow_suspicious_variant_types", "1")
+        .execute()
+        .await?;
+
+    let mut insert = client.insert(table_name)?;
+    let rows_to_insert = get_rows();
+    for row in rows_to_insert {
+        insert.write(&row).await?;
+    }
+    insert.end().await?;
+
+    let rows = client
+        .query("SELECT ?fields FROM ?")
+        .bind(Identifier(table_name))
+        .fetch_all::<MyRow>()
+        .await?;
+
+    println!("{rows:#?}");
+    Ok(())
+}
+
+fn get_rows() -> Vec<MyRow> {
+    vec![
+        MyRow {
+            id: 1,
+            var: MyRowVariant::Array(vec![1, 2]),
+        },
+        MyRow {
+            id: 2,
+            var: MyRowVariant::Boolean(true),
+        },
+        MyRow {
+            id: 3,
+            var: MyRowVariant::Date(
+                time::Date::from_calendar_date(2021, time::Month::January, 1).unwrap(),
+            ),
+        },
+        MyRow {
+            id: 4,
+            var: MyRowVariant::FixedString(*b"foobar"),
+        },
+        MyRow {
+            id: 5,
+            var: MyRowVariant::Float32(100.5),
+        },
+        MyRow {
+            id: 6,
+            var: MyRowVariant::Float64(200.1),
+        },
+        MyRow {
+            id: 7,
+            var: MyRowVariant::Int8(2),
+        },
+        MyRow {
+            id: 8,
+            var: MyRowVariant::Int16(3),
+        },
+        MyRow {
+            id: 9,
+            var: MyRowVariant::Int32(4),
+        },
+        MyRow {
+            id: 10,
+            var: MyRowVariant::Int64(5),
+        },
+        MyRow {
+            id: 11,
+            var: MyRowVariant::Int128(6),
+        },
+        MyRow {
+            id: 12,
+            var: MyRowVariant::String("my_string".to_string()),
+        },
+        MyRow {
+            id: 13,
+            var: MyRowVariant::UInt8(7),
+        },
+        MyRow {
+            id: 14,
+            var: MyRowVariant::UInt16(8),
+        },
+        MyRow {
+            id: 15,
+            var: MyRowVariant::UInt32(9),
+        },
+        MyRow {
+            id: 16,
+            var: MyRowVariant::UInt64(10),
+        },
+        MyRow {
+            id: 17,
+            var: MyRowVariant::UInt128(11),
+        },
+    ]
+}
+
+// As the inner Variant types are _always_ sorted alphabetically,
+// it should be defined in _exactly_ the same order in the enum.
+//
+// Rust enum variants names are irrelevant, only the order of the types matters.
+// This enum represents Variant(Array(UInt16), Bool, FixedString(6), Float32, Float64, Int128, Int16, Int32, Int64, Int8, String, UInt128, UInt16, UInt32, UInt64, UInt8)
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+enum MyRowVariant {
+    Array(Vec<i16>),
+    Boolean(bool),
+    // attributes should work in this case, too
+    #[serde(with = "clickhouse::serde::time::date")]
+    Date(time::Date),
+    // NB: by default, fetched as raw bytes
+    FixedString([u8; 6]),
+    Float32(f32),
+    Float64(f64),
+    Int128(i128),
+    Int16(i16),
+    Int32(i32),
+    Int64(i64),
+    Int8(i8),
+    String(String),
+    UInt128(u128),
+    UInt16(i16),
+    UInt32(u32),
+    UInt64(u64),
+    UInt8(i8),
+}
+
+#[derive(Debug, PartialEq, Row, Serialize, Deserialize)]
+struct MyRow {
+    id: u64,
+    var: MyRowVariant,
+}

--- a/examples/data_types_variant.rs
+++ b/examples/data_types_variant.rs
@@ -135,10 +135,9 @@ fn get_rows() -> Vec<MyRow> {
 }
 
 // As the inner Variant types are _always_ sorted alphabetically,
-// it should be defined in _exactly_ the same order in the enum.
-//
-// Rust enum variants names are irrelevant, only the order of the types matters.
-// This enum represents Variant(Array(UInt16), Bool, FixedString(6), Float32, Float64, Int128, Int16, Int32, Int64, Int8, String, UInt128, UInt16, UInt32, UInt64, UInt8)
+// Rust enum variants should be defined in the _exactly_ same order as it is in the data type;
+// their names are irrelevant, only the order of the types matters.
+// This enum represents Variant(Array(UInt16), Bool, Date, FixedString(6), Float32, Float64, Int128, Int16, Int32, Int64, Int8, String, UInt128, UInt16, UInt32, UInt64, UInt8)
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 enum MyRowVariant {
     Array(Vec<i16>),

--- a/src/error.rs
+++ b/src/error.rs
@@ -32,6 +32,8 @@ pub enum Error {
     InvalidUtf8Encoding(#[from] Utf8Error),
     #[error("tag for enum is not valid")]
     InvalidTagEncoding(usize),
+    #[error("max number of types in the Variant data type is 255, got {0}")]
+    VariantDiscriminatorIsOutOfBound(usize),
     #[error("a custom error message from serde: {0}")]
     Custom(String),
     #[error("bad response: {0}")]

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,8 @@ pub enum Error {
     BadResponse(String),
     #[error("timeout expired")]
     TimedOut,
+    #[error("unsupported: {0}")]
+    Unsupported(String),
 }
 
 assert_impl_all!(Error: StdError, Send, Sync);

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -1,12 +1,12 @@
 use std::{convert::TryFrom, mem, str};
 
+use crate::error::{Error, Result};
 use bytes::Buf;
+use serde::de::{EnumAccess, VariantAccess};
 use serde::{
     de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
     Deserialize,
 };
-
-use crate::error::{Error, Result};
 
 /// Deserializes a value from `input` with a row encoded in `RowBinary`.
 ///
@@ -147,13 +147,78 @@ impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor,
     }
 
     #[inline]
+    fn deserialize_identifier<V: Visitor<'data>>(self, visitor: V) -> Result<V::Value> {
+        self.deserialize_u8(visitor)
+    }
+
+    #[inline]
     fn deserialize_enum<V: Visitor<'data>>(
         self,
-        name: &'static str,
+        _name: &'static str,
         _variants: &'static [&'static str],
-        _visitor: V,
+        visitor: V,
     ) -> Result<V::Value> {
-        panic!("enums are unsupported: `{name}`");
+        struct Access<'de, 'cursor, 'data> {
+            deserializer: &'de mut RowBinaryDeserializer<'cursor, 'data>,
+        }
+        struct VariantDeserializer<'de, 'cursor, 'data> {
+            deserializer: &'de mut RowBinaryDeserializer<'cursor, 'data>,
+        }
+        impl<'data> VariantAccess<'data> for VariantDeserializer<'_, '_, 'data> {
+            type Error = Error;
+
+            fn unit_variant(self) -> Result<()> {
+                Ok(())
+            }
+
+            fn newtype_variant_seed<T>(self, seed: T) -> Result<T::Value>
+            where
+                T: DeserializeSeed<'data>,
+            {
+                DeserializeSeed::deserialize(seed, &mut *self.deserializer)
+            }
+
+            fn tuple_variant<V>(self, len: usize, visitor: V) -> Result<V::Value>
+            where
+                V: Visitor<'data>,
+            {
+                self.deserializer.deserialize_tuple(len, visitor)
+            }
+
+            fn struct_variant<V>(
+                self,
+                fields: &'static [&'static str],
+                visitor: V,
+            ) -> Result<V::Value>
+            where
+                V: Visitor<'data>,
+            {
+                self.deserializer.deserialize_tuple(fields.len(), visitor)
+            }
+        }
+
+        impl<'de, 'cursor, 'data> EnumAccess<'data> for Access<'de, 'cursor, 'data> {
+            type Error = Error;
+            type Variant = VariantDeserializer<'de, 'cursor, 'data>;
+
+            fn variant_seed<T>(
+                self,
+                seed: T,
+            ) -> std::result::Result<(T::Value, Self::Variant), Self::Error>
+            where
+                T: DeserializeSeed<'data>,
+            {
+                seed.deserialize(&mut *self.deserializer).map(|v| {
+                    (
+                        v,
+                        VariantDeserializer {
+                            deserializer: self.deserializer,
+                        },
+                    )
+                })
+            }
+        }
+        visitor.visit_enum(Access { deserializer: self })
     }
 
     #[inline]
@@ -223,11 +288,6 @@ impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor,
     }
 
     #[inline]
-    fn deserialize_identifier<V: Visitor<'data>>(self, _visitor: V) -> Result<V::Value> {
-        panic!("identifiers are unsupported");
-    }
-
-    #[inline]
     fn deserialize_newtype_struct<V: Visitor<'data>>(
         self,
         _name: &str,
@@ -239,20 +299,20 @@ impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor,
     #[inline]
     fn deserialize_unit_struct<V: Visitor<'data>>(
         self,
-        name: &'static str,
+        _name: &'static str,
         _visitor: V,
     ) -> Result<V::Value> {
-        panic!("unit types are unsupported: `{name}`");
+        panic!("unit types are unsupported: `{_name}`");
     }
 
     #[inline]
     fn deserialize_tuple_struct<V: Visitor<'data>>(
         self,
-        name: &'static str,
+        _name: &'static str,
         _len: usize,
         _visitor: V,
     ) -> Result<V::Value> {
-        panic!("tuple struct types are unsupported: `{name}`");
+        panic!("tuple struct types are unsupported: `{_name}`");
     }
 
     #[inline]

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -299,20 +299,20 @@ impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor,
     #[inline]
     fn deserialize_unit_struct<V: Visitor<'data>>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _visitor: V,
     ) -> Result<V::Value> {
-        panic!("unit types are unsupported: `{_name}`");
+        panic!("unit types are unsupported: `{name}`");
     }
 
     #[inline]
     fn deserialize_tuple_struct<V: Visitor<'data>>(
         self,
-        _name: &'static str,
+        name: &'static str,
         _len: usize,
         _visitor: V,
     ) -> Result<V::Value> {
-        panic!("tuple struct types are unsupported: `{_name}`");
+        panic!("tuple struct types are unsupported: `{name}`");
     }
 
     #[inline]

--- a/src/rowbinary/ser.rs
+++ b/src/rowbinary/ser.rs
@@ -139,6 +139,12 @@ impl<'a, B: BufMut> Serializer for &'a mut RowBinarySerializer<B> {
         _variant: &'static str,
         value: &T,
     ) -> Result<()> {
+        // TODO:
+        //  - Now this code implicitly allows using enums at the top level.
+        //    However, instead of a more descriptive panic, it ends with a "not enough data." error.
+        //  - Also, it produces an unclear message for a forgotten `serde_repr` (Enum8 and Enum16).
+        //  See https://github.com/ClickHouse/clickhouse-rs/pull/170#discussion_r1848549636
+
         // Max number of types in the Variant data type is 255
         // See also: https://github.com/ClickHouse/ClickHouse/issues/54864
         if variant_index > 255 {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -66,6 +66,7 @@ mod query;
 mod time;
 mod user_agent;
 mod uuid;
+mod variant;
 mod watch;
 
 const HOST: &str = "localhost:8123";

--- a/tests/it/variant.rs
+++ b/tests/it/variant.rs
@@ -68,59 +68,27 @@ async fn variant_data_type() {
         .await
         .unwrap();
 
-    let rows = vec![
-        MyRow {
-            var: MyRowVariant::Array(vec![1, 2]),
-        },
-        MyRow {
-            var: MyRowVariant::Boolean(true),
-        },
-        MyRow {
-            var: MyRowVariant::Date(time::Date::from_calendar_date(2021, January, 1).unwrap()),
-        },
-        MyRow {
-            var: MyRowVariant::FixedString(*b"foobar"),
-        },
-        MyRow {
-            var: MyRowVariant::Float32(100.5),
-        },
-        MyRow {
-            var: MyRowVariant::Float64(200.1),
-        },
-        MyRow {
-            var: MyRowVariant::Int8(2),
-        },
-        MyRow {
-            var: MyRowVariant::Int16(3),
-        },
-        MyRow {
-            var: MyRowVariant::Int32(4),
-        },
-        MyRow {
-            var: MyRowVariant::Int64(5),
-        },
-        MyRow {
-            var: MyRowVariant::Int128(6),
-        },
-        MyRow {
-            var: MyRowVariant::String("my_string".to_string()),
-        },
-        MyRow {
-            var: MyRowVariant::UInt8(7),
-        },
-        MyRow {
-            var: MyRowVariant::UInt16(8),
-        },
-        MyRow {
-            var: MyRowVariant::UInt32(9),
-        },
-        MyRow {
-            var: MyRowVariant::UInt64(10),
-        },
-        MyRow {
-            var: MyRowVariant::UInt128(11),
-        },
+    let vars = [
+        MyRowVariant::Array(vec![1, 2]),
+        MyRowVariant::Boolean(true),
+        MyRowVariant::Date(time::Date::from_calendar_date(2021, January, 1).unwrap()),
+        MyRowVariant::FixedString(*b"foobar"),
+        MyRowVariant::Float32(100.5),
+        MyRowVariant::Float64(200.1),
+        MyRowVariant::Int8(2),
+        MyRowVariant::Int16(3),
+        MyRowVariant::Int32(4),
+        MyRowVariant::Int64(5),
+        MyRowVariant::Int128(6),
+        MyRowVariant::String("my_string".to_string()),
+        MyRowVariant::UInt8(7),
+        MyRowVariant::UInt16(8),
+        MyRowVariant::UInt32(9),
+        MyRowVariant::UInt64(10),
+        MyRowVariant::UInt128(11),
     ];
+
+    let rows = vars.map(|var| MyRow { var });
 
     // Write to the table.
     let mut insert = client.insert("test_var").unwrap();
@@ -136,10 +104,5 @@ async fn variant_data_type() {
         .await
         .unwrap();
 
-    assert_eq!(result_rows.len(), rows.len());
-    rows.iter()
-        .zip(result_rows.iter())
-        .for_each(|(row, result_row)| {
-            assert_eq!(row, result_row);
-        });
+    assert_eq!(result_rows, rows)
 }

--- a/tests/it/variant.rs
+++ b/tests/it/variant.rs
@@ -1,0 +1,121 @@
+#![cfg(feature = "time")]
+
+use clickhouse::Row;
+use serde::Deserialize;
+use time::Month::January;
+
+// See also: https://clickhouse.com/docs/en/sql-reference/data-types/variant
+
+#[tokio::test]
+async fn variant_data_type() {
+    let client = prepare_database!();
+
+    // NB: Inner Variant types are _always_ sorted alphabetically,
+    // and should be defined in _exactly_ the same order in the enum.
+    #[derive(Debug, PartialEq, Deserialize)]
+    enum MyRowVariant {
+        Array(Vec<i16>),
+        Boolean(bool),
+        // attributes should work in this case, too
+        #[serde(with = "clickhouse::serde::time::date")]
+        Date(time::Date),
+        FixedString([u8; 6]),
+        Float32(f32),
+        Float64(f64),
+        Int128(i128),
+        Int16(i16),
+        Int32(i32),
+        Int64(i64),
+        Int8(i8),
+        String(String),
+        UInt128(u128),
+        UInt16(i16),
+        UInt32(u32),
+        UInt64(u64),
+        UInt8(i8),
+    }
+
+    #[derive(Debug, Row, Deserialize)]
+    struct MyRow {
+        var: MyRowVariant,
+    }
+
+    // No matter the order of the definition on the Variant types, it will always be sorted as follows:
+    // Variant(Array(UInt16), Bool, FixedString(6), Float32, Float64, Int128, Int16, Int32, Int64, Int8, String, UInt128, UInt16, UInt32, UInt64, UInt8)
+    client
+        .query(
+            "
+            CREATE OR REPLACE TABLE test_var
+            (
+                `var` Variant(
+                    Array(UInt16),
+                    Bool,
+                    Date,
+                    FixedString(6),
+                    Float32, Float64,
+                    Int128, Int16, Int32, Int64, Int8,
+                    String,
+                    UInt128, UInt16, UInt32, UInt64, UInt8
+                )
+            )
+            ENGINE = MergeTree
+            ORDER BY ()",
+        )
+        .with_option("allow_experimental_variant_type", "1")
+        .with_option("allow_suspicious_variant_types", "1")
+        .execute()
+        .await
+        .unwrap();
+
+    // Write to the table.
+    client
+        .query(
+            "
+            INSERT INTO test_var VALUES
+                ([1, 2]),
+                (true),
+                ('2021-01-01' :: Date),
+                ('foobar' :: FixedString(6)),
+                (100.5 :: Float32), (200.1 :: Float64),
+                (2 :: Int8), (3 :: Int16), (4 :: Int32), (5 :: Int64), (6 :: Int128),
+                ('my_string' :: String),
+                (7 :: UInt8), (8 :: UInt16), (9 :: UInt32), (10 :: UInt64), (11 :: UInt128)",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    // Read from the table.
+    let rows = client
+        .query("SELECT ?fields FROM test_var")
+        .fetch_all::<MyRow>()
+        .await
+        .unwrap();
+
+    let expected = vec![
+        MyRowVariant::Array(vec![1, 2]),
+        MyRowVariant::Boolean(true),
+        MyRowVariant::Date(time::Date::from_calendar_date(2021, January, 1).unwrap()),
+        MyRowVariant::FixedString(*b"foobar"),
+        MyRowVariant::Float32(100.5),
+        MyRowVariant::Float64(200.1),
+        MyRowVariant::Int8(2),
+        MyRowVariant::Int16(3),
+        MyRowVariant::Int32(4),
+        MyRowVariant::Int64(5),
+        MyRowVariant::Int128(6),
+        MyRowVariant::String("my_string".to_string()),
+        MyRowVariant::UInt8(7),
+        MyRowVariant::UInt16(8),
+        MyRowVariant::UInt32(9),
+        MyRowVariant::UInt64(10),
+        MyRowVariant::UInt128(11),
+    ];
+
+    assert_eq!(rows.len(), expected.len());
+    rows.iter()
+        .zip(expected.iter())
+        .for_each(|(row, expected)| {
+            assert_eq!(row.var, *expected);
+        });
+}


### PR DESCRIPTION
## Summary

Adds support for the [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant). Closes #143.

To discuss:
- can we make a convenience macro to generate the enum? Or is it more of the ch2rs responsibility in this case?

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [x] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
