### PR TITLE
Add Docker Compose for easier local development

### DIFF
--- a/.docker/clickhouse/single_node/config.xml
+++ b/.docker/clickhouse/single_node/config.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<clickhouse>
+
+  <http_port>8123</http_port>
+  <tcp_port>9000</tcp_port>
+
+  <users_config>users.xml</users_config>
+  <default_profile>default</default_profile>
+  <default_database>default</default_database>
+
+  <mark_cache_size>5368709120</mark_cache_size>
+
+  <path>/var/lib/clickhouse/</path>
+  <tmp_path>/var/lib/clickhouse/tmp/</tmp_path>
+  <user_files_path>/var/lib/clickhouse/user_files/</user_files_path>
+  <access_control_path>/var/lib/clickhouse/access/</access_control_path>
+
+  <logger>
+    <level>debug</level>
+    <log>/var/log/clickhouse-server/clickhouse-server.log</log>
+    <errorlog>/var/log/clickhouse-server/clickhouse-server.err.log</errorlog>
+    <size>1000M</size>
+    <count>10</count>
+    <console>1</console>
+  </logger>
+
+  <query_log>
+    <database>system</database>
+    <table>query_log</table>
+    <partition_by>toYYYYMM(event_date)</partition_by>
+    <flush_interval_milliseconds>1000</flush_interval_milliseconds>
+  </query_log>
+</clickhouse>

--- a/.docker/clickhouse/users.xml
+++ b/.docker/clickhouse/users.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<clickhouse>
+
+  <profiles>
+    <default>
+      <load_balancing>random</load_balancing>
+    </default>
+  </profiles>
+
+  <users>
+    <default>
+      <password></password>
+      <networks>
+        <ip>::/0</ip>
+      </networks>
+      <profile>default</profile>
+      <quota>default</quota>
+      <access_management>1</access_management>
+    </default>
+  </users>
+
+  <quotas>
+    <default>
+      <interval>
+        <duration>3600</duration>
+        <queries>0</queries>
+        <errors>0</errors>
+        <result_rows>0</result_rows>
+        <read_rows>0</read_rows>
+        <execution_time>0</execution_time>
+      </interval>
+    </default>
+  </quotas>
+</clickhouse>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+services:
+  clickhouse:
+    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-24.10-alpine}'
+    container_name: 'clickhouse-rs-clickhouse-server'
+    ports:
+      - '8123:8123'
+      - '9000:9000'
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+    volumes:
+      - './.docker/clickhouse/single_node/config.xml:/etc/clickhouse-server/config.xml'
+      - './.docker/clickhouse/users.xml:/etc/clickhouse-server/users.xml'


### PR DESCRIPTION
## Summary
Similar to https://github.com/ClickHouse/clickhouse-js/tree/main/.docker/clickhouse
If a cluster setup will be required, it can be easily added, too.

NB: it could be the latest instead of a fixed version, _but_ it will be more annoying, as IIRC Docker won't pull an updated `latest` version if there is one cached already (need to execute `docker compose pull` first)
