### PR TITLE
Don't specify 'readonly' twice if it appears in the client's option list

### DIFF
--- a/src/query.rs
+++ b/src/query.rs
@@ -147,7 +147,7 @@ impl Query {
         let use_post = !read_only || query.len() > MAX_QUERY_LEN_TO_USE_GET;
 
         let (method, body, content_length) = if use_post {
-            if read_only {
+            if read_only && !self.client.options.contains_key("readonly") {
                 pairs.append_pair("readonly", "1");
             }
             let len = query.len();

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -106,6 +106,16 @@ async fn long_query() {
         .unwrap();
 
     assert_eq!(got_string, long_string);
+
+    let got_string = client
+        .query("select ?")
+        .bind(&long_string)
+        .with_option("readonly", "2")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+
+    assert_eq!(got_string, long_string);
 }
 
 // See #22.


### PR DESCRIPTION
## Summary

If a user specifies the "readonly" option at the client level and tries to execute a query too long to fit in the GET request's query parameters, "readonly" is set twice in the header - once as "1" and again as whatever the user specified. In particular, this means it's not possible to set another value for "readonly" on queries that use the POST method. Bypass setting "readonly" the first time if it's part of the Client's options already.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later