### PR TITLE
fix: MSRV issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
 
     services:
       clickhouse:
-        image: clickhouse/clickhouse-server
+        image: clickhouse/clickhouse-server:24.10-alpine
         ports:
           - 8123:8123
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
   RUSTFLAGS: -Dwarnings
   RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
-  MSRV: 1.70.0
+  MSRV: 1.73.0
 
 jobs:
   build:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ lz4_flex = { version = "0.11.3", default-features = false, features = [
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
-bstr = { version = "1.11.0", default-features = false } # 1.11.0+ is Rust 1.73+ only
+bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 edition = "2021"
 # update `derive/Cargo.toml` and CI if changed
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 
 [lints.rust]
 rust_2018_idioms = { level = "warn", priority = -1 }
@@ -85,10 +85,10 @@ hyper = "1.4"
 hyper-util = { version = "0.1.6", features = ["client-legacy", "http1"] }
 hyper-tls = { version = "0.6.0", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-hyper-rustls = { version = "=0.27.2", default-features = false, features = [
+hyper-rustls = { version = "0.27.3", default-features = false, features = [
     "http1",
     "tls12",
-], optional = true } # 0.27.3+ is Rust 1.71+ only
+], optional = true }
 url = "2.1.1"
 futures = "0.3.5"
 futures-channel = "0.3.30"
@@ -102,7 +102,7 @@ lz4_flex = { version = "0.11.3", default-features = false, features = [
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
-bstr = { version = "=1.10.0", default-features = false } # 1.11.0+ is Rust 1.73+ only
+bstr = { version = "1.11.0", default-features = false } # 1.11.0+ is Rust 1.73+ only
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ lz4_flex = { version = "0.11.3", default-features = false, features = [
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
-bstr = { version = "1.2", default-features = false }
+bstr = { version = "1.11.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,10 +85,10 @@ hyper = "1.4"
 hyper-util = { version = "0.1.6", features = ["client-legacy", "http1"] }
 hyper-tls = { version = "0.6.0", optional = true }
 rustls = { version = "0.23", default-features = false, optional = true }
-hyper-rustls = { version = "0.27.2", default-features = false, features = [
+hyper-rustls = { version = "=0.27.2", default-features = false, features = [
     "http1",
     "tls12",
-], optional = true }
+], optional = true } # 0.27.3+ is Rust 1.71+ only
 url = "2.1.1"
 futures = "0.3.5"
 futures-channel = "0.3.30"
@@ -102,7 +102,7 @@ lz4_flex = { version = "0.11.3", default-features = false, features = [
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
-bstr = { version = "=1.10.0", default-features = false }
+bstr = { version = "=1.10.0", default-features = false } # 1.11.0+ is Rust 1.73+ only
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,7 +102,7 @@ lz4_flex = { version = "0.11.3", default-features = false, features = [
 cityhash-rs = { version = "=1.0.1", optional = true } # exact version for safety
 uuid = { version = "1", optional = true }
 time = { version = "0.3", optional = true }
-bstr = { version = "1.11.0", default-features = false }
+bstr = { version = "=1.10.0", default-features = false }
 quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -8,7 +8,7 @@ homepage = "https://clickhouse.com"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 # update `Cargo.toml` and CI if changed
-rust-version = "1.70.0"
+rust-version = "1.73.0"
 
 [lib]
 proc-macro = true

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -25,7 +25,7 @@ struct RowBinaryDeserializer<'cursor, 'data> {
     input: &'cursor mut &'data [u8],
 }
 
-impl<'cursor, 'data> RowBinaryDeserializer<'cursor, 'data> {
+impl<'data> RowBinaryDeserializer<'_, 'data> {
     fn read_vec(&mut self, size: usize) -> Result<Vec<u8>> {
         Ok(self.read_slice(size)?.to_vec())
     }
@@ -64,7 +64,7 @@ macro_rules! impl_num {
     };
 }
 
-impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor, 'data> {
+impl<'data> Deserializer<'data> for &mut RowBinaryDeserializer<'_, 'data> {
     type Error = Error;
 
     impl_num!(i8, deserialize_i8, visit_i8, get_i8);
@@ -163,7 +163,7 @@ impl<'cursor, 'data> Deserializer<'data> for &mut RowBinaryDeserializer<'cursor,
             len: usize,
         }
 
-        impl<'de, 'cursor, 'data> SeqAccess<'data> for Access<'de, 'cursor, 'data> {
+        impl<'data> SeqAccess<'data> for Access<'_, '_, 'data> {
             type Error = Error;
 
             fn next_element_seed<T>(&mut self, seed: T) -> Result<Option<T::Value>>

--- a/src/rowbinary/ser.rs
+++ b/src/rowbinary/ser.rs
@@ -30,7 +30,7 @@ macro_rules! impl_num {
     };
 }
 
-impl<'a, B: BufMut> Serializer for &'a mut RowBinarySerializer<B> {
+impl<B: BufMut> Serializer for &'_ mut RowBinarySerializer<B> {
     type Error = Error;
     type Ok = ();
     type SerializeMap = Impossible<(), Error>;
@@ -201,7 +201,7 @@ impl<'a, B: BufMut> Serializer for &'a mut RowBinarySerializer<B> {
     }
 }
 
-impl<'a, B: BufMut> SerializeStruct for &'a mut RowBinarySerializer<B> {
+impl<B: BufMut> SerializeStruct for &mut RowBinarySerializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -216,7 +216,7 @@ impl<'a, B: BufMut> SerializeStruct for &'a mut RowBinarySerializer<B> {
     }
 }
 
-impl<'a, B: BufMut> SerializeSeq for &'a mut RowBinarySerializer<B> {
+impl<B: BufMut> SerializeSeq for &'_ mut RowBinarySerializer<B> {
     type Error = Error;
     type Ok = ();
 
@@ -229,7 +229,7 @@ impl<'a, B: BufMut> SerializeSeq for &'a mut RowBinarySerializer<B> {
     }
 }
 
-impl<'a, B: BufMut> SerializeTuple for &'a mut RowBinarySerializer<B> {
+impl<B: BufMut> SerializeTuple for &'_ mut RowBinarySerializer<B> {
     type Error = Error;
     type Ok = ();
 

--- a/src/sql/bind.rs
+++ b/src/sql/bind.rs
@@ -24,7 +24,7 @@ impl<S: Serialize> Bind for S {
 pub struct Identifier<'a>(pub &'a str);
 
 #[sealed]
-impl<'a> Bind for Identifier<'a> {
+impl Bind for Identifier<'_> {
     #[inline]
     fn write(&self, dst: &mut impl fmt::Write) -> Result<(), String> {
         escape::identifier(self.0, dst).map_err(|err| err.to_string())

--- a/src/sql/ser.rs
+++ b/src/sql/ser.rs
@@ -226,7 +226,7 @@ struct SqlListSerializer<'a, W> {
     closing_char: char,
 }
 
-impl<'a, W: Write> SerializeSeq for SqlListSerializer<'a, W> {
+impl<W: Write> SerializeSeq for SqlListSerializer<'_, W> {
     type Error = SerializerError;
     type Ok = ();
 
@@ -253,7 +253,7 @@ impl<'a, W: Write> SerializeSeq for SqlListSerializer<'a, W> {
     }
 }
 
-impl<'a, W: Write> SerializeTuple for SqlListSerializer<'a, W> {
+impl<W: Write> SerializeTuple for SqlListSerializer<'_, W> {
     type Error = SerializerError;
     type Ok = ();
 

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -28,9 +28,9 @@ async fn max_execution_time(client: Client) -> Vec<u64> {
         .with_compression(Compression::None)
         // reducing max_block_size to force the server to stream one row at a time
         .with_option("max_block_size", "1")
-        // with sleepEachRow(0.01) this ensures that the query will fail after the second row
-        .with_option("max_execution_time", "0.025")
-        .query("SELECT number, sleepEachRow(0.01) AS sleep FROM system.numbers LIMIT 3")
+        // with sleepEachRow(0.1) this ensures that the query will fail after the second row
+        .with_option("max_execution_time", "0.25")
+        .query("SELECT number, sleepEachRow(0.1) AS sleep FROM system.numbers LIMIT 3")
         .fetch::<Res>()
         .unwrap();
 

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -20,7 +20,7 @@ async fn max_execution_time(mut client: Client, wait_end_of_query: bool) {
     // TODO: check different `timeout_overflow_mode`
     let mut cursor = client
         .with_compression(Compression::None)
-        .with_option("max_execution_time", "0.1")
+        .with_option("max_execution_time", "0.01")
         .query("SELECT toUInt8(65 + number % 5) FROM system.numbers LIMIT 100000000")
         .fetch::<u8>()
         .unwrap();

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -20,8 +20,8 @@ async fn max_execution_time(mut client: Client, wait_end_of_query: bool) {
     // TODO: check different `timeout_overflow_mode`
     let mut cursor = client
         .with_compression(Compression::None)
-        .with_option("max_execution_time", "0.01")
-        .query("SELECT toUInt8(65 + number % 5) FROM system.numbers LIMIT 100000000")
+        .with_option("max_execution_time", "0.05")
+        .query("SELECT toUInt8(65 + number % 5) FROM system.numbers LIMIT 1000000000")
         .fetch::<u8>()
         .unwrap();
 
@@ -38,6 +38,8 @@ async fn max_execution_time(mut client: Client, wait_end_of_query: bool) {
             Err(err) => break err,
         }
     };
+
+    println!("i: {}", i);
 
     assert!(wait_end_of_query ^ (i != 0));
     assert!(err.to_string().contains("TIMEOUT_EXCEEDED"));

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -21,7 +21,7 @@ async fn max_execution_time(mut client: Client, wait_end_of_query: bool) {
     let mut cursor = client
         .with_compression(Compression::None)
         .with_option("max_execution_time", "0.05")
-        .query("SELECT toUInt8(65 + number % 5) FROM system.numbers LIMIT 1000000000")
+        .query("SELECT toUInt8(65 + number % 100) FROM system.numbers LIMIT 1000000000")
         .fetch::<u8>()
         .unwrap();
 
@@ -31,7 +31,7 @@ async fn max_execution_time(mut client: Client, wait_end_of_query: bool) {
         match cursor.next().await {
             Ok(Some(no)) => {
                 // Check that we haven't parsed something extra.
-                assert_eq!(no, (65 + i % 5) as u8);
+                assert_eq!(no, (65 + i % 100) as u8);
                 i += 1;
             }
             Ok(None) => panic!("DB exception hasn't been found"),


### PR DESCRIPTION
- The latest `bstr` version requires Rust 1.71 
- The latest `hyper-rustls` version requires Rust 1.73
- CH version is temporarily pinned to 24.10 (should be bumped after https://github.com/ClickHouse/clickhouse-rs/issues/177)