### PR TITLE
Exposed method to control the `readonly` query parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,12 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - query/cursor: improve performance of `RowCursor::next()` ([#169]).
+- exposed method to control the `readonly` query parameter ([#181]).
 
 ### Fixed
 - mock: work with the advanced time via `tokio::time::advance()` ([#165]).
 
 [#165]: https://github.com/ClickHouse/clickhouse-rs/pull/165
 [#169]: https://github.com/ClickHouse/clickhouse-rs/pull/169
+[#181]: https://github.com/ClickHouse/clickhouse-rs/pull/181
 
 ## [0.13.0] - 2024-09-27
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - query/cursor: improve performance of `RowCursor::next()` ([#169]).
-- exposed method to control the `readonly` query parameter ([#181]).
+- query: exposed method to control the `readonly` query parameter ([#181]).
 
 ### Fixed
 - mock: work with the advanced time via `tokio::time::advance()` ([#165]).

--- a/src/query.rs
+++ b/src/query.rs
@@ -60,7 +60,7 @@ impl Query {
 
     /// Executes the query.
     pub async fn execute(self) -> Result<()> {
-        self.read_only(false).do_execute()?.finish().await
+        self.do_execute()?.finish().await
     }
 
     /// Executes the query, returning a [`RowCursor`] to obtain results.

--- a/src/watch.rs
+++ b/src/watch.rs
@@ -254,7 +254,7 @@ async fn init_cursor<T>(client: &Client, params: &WatchParams) -> Result<JsonCur
 
     watch_sql.push_str(" FORMAT JSONEachRowWithProgress");
 
-    let response = client.query(&watch_sql).do_execute(true)?;
+    let response = client.query(&watch_sql).do_execute()?;
     Ok(JsonCursor::new(response))
 }
 


### PR DESCRIPTION
## Summary

This PR is meant to improve the control over the readonly option sent by the client to the CH database. Right now, it is defined by some methods like [`Query::do_execute`](https://github.com/ClickHouse/clickhouse-rs/blob/main/src/query.rs#L135C19-L135C29), but most of the public methods like Query::fetch, [`Query::fetch_one`](https://github.com/ClickHouse/clickhouse-rs/blob/main/src/query.rs#L96C18-L96C27), or [`Query::fetch_all`](https://github.com/ClickHouse/clickhouse-rs/blob/main/src/query.rs#L121C18-L121C27) don’t have control over this option. This makes it impossible to query the database with queries that contain a lot of columns and require temporary table creation on the database side, which results in the following error:

> Code: 164. DB::Exception: db_user: Cannot execute query in readonly mode. (READONLY) (version 24.10.1.2812 (official build))

By adding the changes in this PR, we will gain control over this option, making it possible to request data that requires the creation of temporary tables by CH.


## Checklist
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
