### PR TITLE
Always use POST for queries; disable readonly setting by default

### DIFF
--- a/src/request_body.rs
+++ b/src/request_body.rs
@@ -25,10 +25,6 @@ enum Message {
 }
 
 impl RequestBody {
-    pub(crate) fn empty() -> Self {
-        Self(Inner::Full(Bytes::new()))
-    }
-
     pub(crate) fn full(content: String) -> Self {
         Self(Inner::Full(Bytes::from(content)))
     }


### PR DESCRIPTION
## Summary

See https://github.com/ClickHouse/clickhouse-rs/pull/181; perhaps it is better not to enforce it by default at all. Additionally, it is possibly safer to just always send queries via the POST body, as long URLs could be truncated by the proxies. 

This is a breaking change (`readonly` setting is no longer set by default for queries that fetch data)

## Checklist
- [ ] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
