### PR TITLE
fix(cursor): return NotEnoughData

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [Variant data type](https://clickhouse.com/docs/en/sql-reference/data-types/variant) support ([#170]).
 
+### Fixed
+- query/cursor: return `NotEnoughData` if a row is unparsed when the stream ends ([#185]).
+
 [#170]: https://github.com/ClickHouse/clickhouse-rs/pull/170
+[#185]: https://github.com/ClickHouse/clickhouse-rs/pull/185
 
 ## [0.13.1] - 2024-10-21
 ### Added

--- a/src/cursor.rs
+++ b/src/cursor.rs
@@ -126,6 +126,11 @@ impl<T> RowCursor<T> {
 
             match self.raw.next().await? {
                 Some(chunk) => self.bytes.extend(chunk),
+                None if self.bytes.remaining() > 0 => {
+                    // If some data is left, we have an incomplete row in the buffer.
+                    // This is usually a schema mismatch on the client side.
+                    return Err(Error::NotEnoughData);
+                }
                 None => return Ok(None),
             }
         }

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -2,9 +2,8 @@ use std::{convert::TryFrom, mem, str};
 
 use crate::error::{Error, Result};
 use bytes::Buf;
-use serde::de::{EnumAccess, VariantAccess};
 use serde::{
-    de::{DeserializeSeed, Deserializer, SeqAccess, Visitor},
+    de::{DeserializeSeed, Deserializer, EnumAccess, SeqAccess, VariantAccess, Visitor},
     Deserialize,
 };
 


### PR DESCRIPTION
## Summary
It fixes the regression introduced in #169.
Previously, the cursor checked if unhandled bytes were left.
Return this behavior to detect schema mismatch.

Closes #185

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
