### PR TITLE
derive: Support `#[row(crate = ...)]`

### DIFF
--- a/derive/src/attributes/mod.rs
+++ b/derive/src/attributes/mod.rs
@@ -1,0 +1,2 @@
+mod row;
+pub use row::Row;

--- a/derive/src/attributes/row.rs
+++ b/derive/src/attributes/row.rs
@@ -1,0 +1,43 @@
+use quote::ToTokens;
+
+pub const ATTRIBUTE_NAME: &str = "row";
+pub const ATTRIBUTE_SYNTAX: &str = "#[row(crate = ...)]";
+
+pub const CRATE_PATH: &str = "crate";
+pub const DEFAULT_CRATE_PATH: &str = "::clickhouse";
+
+pub struct Row {
+    pub crate_path: syn::Path,
+}
+
+impl Default for Row {
+    fn default() -> Self {
+        let default_crate_path = syn::parse_str::<syn::Path>(DEFAULT_CRATE_PATH).unwrap();
+        Self {
+            crate_path: default_crate_path,
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a syn::Attribute> for Row {
+    type Error = &'a syn::Attribute;
+
+    fn try_from(attr: &'a syn::Attribute) -> Result<Self, Self::Error> {
+        if attr.path().is_ident(ATTRIBUTE_NAME) {
+            let row = attr.parse_args::<syn::Expr>().unwrap();
+            let syn::Expr::Assign(syn::ExprAssign { left, right, .. }) = row else {
+                panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+            };
+            if left.to_token_stream().to_string() != CRATE_PATH {
+                panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+            }
+            let syn::Expr::Path(syn::ExprPath { path, .. }) = *right else {
+                panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+            };
+            Ok(Self { crate_path: path })
+        } else {
+            return Err(attr);
+        }
+    }
+}
+

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -54,10 +54,9 @@ pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
-    // TODO: replace `clickhouse` with `::clickhouse` here.
     let expanded = quote! {
         #[automatically_derived]
-        impl #impl_generics clickhouse::Row for #name #ty_generics #where_clause {
+        impl #impl_generics ::clickhouse::Row for #name #ty_generics #where_clause {
             const COLUMN_NAMES: &'static [&'static str] = #column_names;
         }
     };

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -55,7 +55,6 @@ fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStr
 
 // TODO: support wrappers `Wrapper(Inner)` and `Wrapper<T>(T)`.
 // TODO: support the `nested` attribute.
-// TODO: support the `crate` attribute.
 #[proc_macro_derive(Row, attributes(row))]
 pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -1,10 +1,48 @@
 use proc_macro2::TokenStream;
-use quote::quote;
+use quote::{quote, ToTokens};
 use serde_derive_internals::{
     attr::{Container, Default as SerdeDefault, Field},
     Ctxt,
 };
 use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields};
+
+struct Attributes {
+    crate_name: syn::Path,
+}
+
+impl From<&[syn::Attribute]> for Attributes {
+    fn from(attrs: &[syn::Attribute]) -> Self {
+        const ATTRIBUTE_NAME: &str = "row";
+        const ATTRIBUTE_SYNTAX: &str = "#[row(crate = ...)]";
+
+        const CRATE_NAME: &str = "crate";
+        const DEFAULT_CRATE_NAME: &str = "clickhouse";
+
+        let mut crate_name = None;
+        for attr in attrs {
+            if attr.path().is_ident(ATTRIBUTE_NAME) {
+                let row = attr.parse_args::<syn::Expr>().unwrap();
+                let syn::Expr::Assign(syn::ExprAssign { left, right, .. }) = row else {
+                    panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+                };
+                if left.to_token_stream().to_string() != CRATE_NAME {
+                    panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+                }
+                let syn::Expr::Path(syn::ExprPath { path, .. }) = *right else {
+                    panic!("expected `{}`", ATTRIBUTE_SYNTAX);
+                };
+                crate_name = Some(path);
+            }
+        }
+        let crate_name = crate_name.unwrap_or_else(|| {
+            syn::Path::from(syn::Ident::new(
+                DEFAULT_CRATE_NAME,
+                proc_macro2::Span::call_site(),
+            ))
+        });
+        Self { crate_name }
+    }
+}
 
 fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStream {
     match &data.fields {
@@ -36,11 +74,12 @@ fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStr
 // TODO: support wrappers `Wrapper(Inner)` and `Wrapper<T>(T)`.
 // TODO: support the `nested` attribute.
 // TODO: support the `crate` attribute.
-#[proc_macro_derive(Row)]
+#[proc_macro_derive(Row, attributes(row))]
 pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
 
     let cx = Ctxt::new();
+    let Attributes { crate_name } = Attributes::from(input.attrs.as_slice());
     let container = Container::from_ast(&cx, &input);
     let name = input.ident;
 
@@ -56,7 +95,7 @@ pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
     let expanded = quote! {
         #[automatically_derived]
-        impl #impl_generics ::clickhouse::Row for #name #ty_generics #where_clause {
+        impl #impl_generics #crate_name::Row for #name #ty_generics #where_clause {
             const COLUMN_NAMES: &'static [&'static str] = #column_names;
         }
     };

--- a/src/row.rs
+++ b/src/row.rs
@@ -75,21 +75,21 @@ pub(crate) fn join_column_names<R: Row>() -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    // XXX: need for `derive(Row)`. Provide `row(crate = ..)` instead.
-    use crate as clickhouse;
-    use clickhouse::Row;
+    use crate::Row;
 
     use super::*;
 
     #[test]
     fn it_grabs_simple_struct() {
         #[derive(Row)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct Simple1 {
             one: u32,
         }
 
         #[derive(Row)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct Simple2 {
             one: u32,
@@ -103,6 +103,7 @@ mod tests {
     #[test]
     fn it_grabs_mix() {
         #[derive(Row)]
+        #[row(crate = crate)]
         struct SomeRow {
             _a: u32,
         }
@@ -115,6 +116,7 @@ mod tests {
         use serde::Serialize;
 
         #[derive(Row, Serialize)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct TopLevel {
             #[serde(rename = "two")]
@@ -129,6 +131,7 @@ mod tests {
         use serde::Serialize;
 
         #[derive(Row, Serialize)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct TopLevel {
             one: u32,
@@ -144,6 +147,7 @@ mod tests {
         use serde::Deserialize;
 
         #[derive(Row, Deserialize)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct TopLevel {
             one: u32,
@@ -158,6 +162,7 @@ mod tests {
     fn it_rejects_other() {
         #[allow(dead_code)]
         #[derive(Row)]
+        #[row(crate = crate)]
         struct NamedTuple(u32, u32);
 
         assert_eq!(join_column_names::<u32>(), None);
@@ -170,6 +175,7 @@ mod tests {
         use serde::Serialize;
 
         #[derive(Row, Serialize)]
+        #[row(crate = crate)]
         #[allow(dead_code)]
         struct MyRow {
             r#type: u32,

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -149,12 +149,11 @@ impl SqlBuilder {
 mod tests {
     use super::*;
 
-    // XXX: need for `derive(Row)`. Provide `row(crate = ..)` instead.
-    use crate as clickhouse;
     use clickhouse_derive::Row;
 
     #[allow(unused)]
     #[derive(Row)]
+    #[row(crate = crate)]
     struct Row {
         a: u32,
         b: u32,
@@ -162,6 +161,7 @@ mod tests {
 
     #[allow(unused)]
     #[derive(Row)]
+    #[row(crate = crate)]
     struct Unnamed(u32, u32);
 
     #[test]


### PR DESCRIPTION
## Summary
- A quick fix for a small TODO in `derive` crate.
- Add support for `#[row(crate = ...)]` attribute
