### PR TITLE
docs: fix typo in DateTime64 description

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ How to choose between all these features? Here are some considerations:
     }
     ```
     </details>
-* `DateTime64(_)` maps to/from `i32` or a newtype around it and represents a time elapsed since UNIX epoch. Also, [`time::OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html) is supported by using `serde::time::datetime64::*`, that requires the `time` feature.
+* `DateTime64(_)` maps to/from `i64` or a newtype around it and represents a time elapsed since UNIX epoch. Also, [`time::OffsetDateTime`](https://docs.rs/time/latest/time/struct.OffsetDateTime.html) is supported by using `serde::time::datetime64::*`, that requires the `time` feature.
     <details>
     <summary>Example</summary>
 


### PR DESCRIPTION
## Summary
Fixed typo in docs that said that `DateTime64(_)` mapped to/from `i32`.

## Checklist
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
