### PR TITLE
fix: better HTTPS errors with disabled `native-tls` or `rustls-tls`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,12 +100,14 @@ jobs:
       - run: cargo test --features uuid,time
       - run: cargo test --all-features
 
-      # Temporary runs tests with `cloud_` prefix only until we validate that the rest of the tests are working
       - name: Run tests with ClickHouse Cloud
         env:
           CLICKHOUSE_TEST_ENVIRONMENT: cloud
           CLICKHOUSE_CLOUD_HOST: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_HOST_SMT }}
           CLICKHOUSE_CLOUD_PASSWORD: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_PASSWORD_SMT }}
           CLICKHOUSE_CLOUD_JWT_ACCESS_TOKEN: ${{ secrets.INTEGRATIONS_TEAM_TESTS_CLOUD_JWT_DESERT_VM_43 }}
+        # Temporary runs tests with `cloud_` prefix only until we validate that the rest of the tests are working
+        # `https_errors` should assert ClickHouse Cloud connection errors without enabled TLS features
         run: |
           cargo test cloud_ --features rustls-tls -- --nocapture
+          cargo test https_errors -- --nocapture

--- a/tests/it/https_errors.rs
+++ b/tests/it/https_errors.rs
@@ -1,0 +1,30 @@
+use crate::{get_cloud_url, require_env_var};
+use clickhouse::Client;
+
+#[tokio::test]
+async fn test_https_error_on_missing_feature() {
+    check_cloud_test_env!();
+    let valid_token = require_env_var("CLICKHOUSE_CLOUD_JWT_ACCESS_TOKEN");
+    let client = Client::default()
+        .with_url(get_cloud_url())
+        .with_access_token(valid_token);
+    let result = client
+        .query("SELECT 42")
+        .fetch_one::<u8>()
+        .await
+        .err()
+        .map(|e| e.to_string())
+        .expect("expected a TLS Error, got Ok instead");
+
+    for fragment in [
+        "invalid URL, scheme is not http",
+        "HTTPS",
+        "`native-tls` or `rustls-tls`",
+    ] {
+        assert!(
+            result.contains(fragment),
+            "TLS error message should contain `{}`",
+            fragment
+        );
+    }
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -115,6 +115,7 @@ mod compression;
 mod cursor_error;
 mod cursor_stats;
 mod fetch_bytes;
+mod https_errors;
 mod insert;
 mod inserter;
 mod int128;


### PR DESCRIPTION
## Summary

Closes #217 

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
