### PR TITLE
feat(insert): `RowBinaryWithNamesAndTypes`

### DIFF
--- a/benches/mocked_insert.rs
+++ b/benches/mocked_insert.rs
@@ -51,7 +51,7 @@ async fn run_insert(client: Client, addr: SocketAddr, iters: u64) -> Result<Dura
     let _server = common::start_server(addr, serve).await;
 
     let start = Instant::now();
-    let mut insert = client.insert("table")?;
+    let mut insert = client.insert("table").await?;
 
     for _ in 0..iters {
         insert.write(&SomeRow::sample()).await?;
@@ -70,7 +70,7 @@ async fn run_inserter<const WITH_PERIOD: bool>(
     let _server = common::start_server(addr, serve).await;
 
     let start = Instant::now();
-    let mut inserter = client.inserter("table")?.with_max_rows(iters);
+    let mut inserter = client.inserter("table").with_max_rows(iters);
 
     if WITH_PERIOD {
         // Just to measure overhead, not to actually use it.
@@ -78,7 +78,7 @@ async fn run_inserter<const WITH_PERIOD: bool>(
     }
 
     for _ in 0..iters {
-        inserter.write(&SomeRow::sample())?;
+        inserter.write(&SomeRow::sample()).await?;
         inserter.commit().await?;
     }
 

--- a/examples/async_insert.rs
+++ b/examples/async_insert.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     insert
         .write(&Event {
             timestamp: now(),

--- a/examples/data_types_derive_containers.rs
+++ b/examples/data_types_derive_containers.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     insert.write(&Row::new()).await?;
     insert.end().await?;
 

--- a/examples/data_types_derive_simple.rs
+++ b/examples/data_types_derive_simple.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     insert.write(&Row::new()).await?;
     insert.end().await?;
 

--- a/examples/data_types_new_json.rs
+++ b/examples/data_types_new_json.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
         .to_string(),
     };
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     insert.write(&row).await?;
     insert.end().await?;
 

--- a/examples/data_types_variant.rs
+++ b/examples/data_types_variant.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     let rows_to_insert = get_rows();
     for row in rows_to_insert {
         insert.write(&row).await?;

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         Error = 4,
     }
 
-    let mut insert = client.insert("event_log")?;
+    let mut insert = client.insert("event_log").await?;
     insert
         .write(&Event {
             timestamp: now(),

--- a/examples/inserter.rs
+++ b/examples/inserter.rs
@@ -22,7 +22,7 @@ struct MyRow {
 // In other words, this pattern is applicable for ETL-like tasks.
 async fn dense(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
     let mut inserter = client
-        .inserter(TABLE_NAME)?
+        .inserter(TABLE_NAME)
         // We limit the number of rows to be inserted in a single `INSERT` statement.
         // We use small value (100) for the example only.
         // See documentation of `with_max_rows` for details.
@@ -32,7 +32,7 @@ async fn dense(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
         .with_max_bytes(1_048_576);
 
     while let Some(no) = rx.recv().await {
-        inserter.write(&MyRow { no })?;
+        inserter.write(&MyRow { no }).await?;
         inserter.commit().await?;
     }
 
@@ -47,7 +47,7 @@ async fn dense(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
 // Some rows are arriving one by one with delay, some batched.
 async fn sparse(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
     let mut inserter = client
-        .inserter(TABLE_NAME)?
+        .inserter(TABLE_NAME)
         // Slice the stream into chunks (one `INSERT` per chunk) by time.
         // See documentation of `with_period` for details.
         .with_period(Some(Duration::from_millis(100)))
@@ -85,7 +85,7 @@ async fn sparse(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
             Err(TryRecvError::Disconnected) => break,
         };
 
-        inserter.write(&MyRow { no })?;
+        inserter.write(&MyRow { no }).await?;
         inserter.commit().await?;
 
         // You can use result of `commit()` to get the number of rows inserted.

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -19,7 +19,7 @@ async fn make_select(client: &Client) -> Result<Vec<SomeRow>> {
 }
 
 async fn make_insert(client: &Client, data: &[SomeRow]) -> Result<()> {
-    let mut insert = client.insert("who cares")?;
+    let mut insert = client.insert("who cares").await?;
     for row in data {
         insert.write(row).await?;
     }

--- a/examples/session_id.rs
+++ b/examples/session_id.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         i: i32,
     }
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert(table_name).await?;
     insert.write(&MyRow { i: 42 }).await?;
     insert.end().await?;
 

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -29,7 +29,7 @@ async fn ddl(client: &Client) -> Result<()> {
 }
 
 async fn insert(client: &Client) -> Result<()> {
-    let mut insert = client.insert("some")?;
+    let mut insert = client.insert("some").await?;
     for i in 0..1000 {
         insert.write(&MyRow { no: i, name: "foo" }).await?;
     }
@@ -42,12 +42,12 @@ async fn insert(client: &Client) -> Result<()> {
 #[cfg(feature = "inserter")]
 async fn inserter(client: &Client) -> Result<()> {
     let mut inserter = client
-        .inserter("some")?
+        .inserter("some")
         .with_max_rows(100_000)
         .with_period(Some(std::time::Duration::from_secs(15)));
 
     for i in 0..1000 {
-        inserter.write(&MyRow { no: i, name: "foo" })?;
+        inserter.write(&MyRow { no: i, name: "foo" }).await?;
         inserter.commit().await?;
     }
 
@@ -116,7 +116,7 @@ async fn watch(client: &Client) -> Result<()> {
     let (version, row) = cursor.next().await?.unwrap();
     println!("version={version}, row={row:?}");
 
-    let mut insert = client.insert("some")?;
+    let mut insert = client.insert("some").await?;
     let row = MyRow {
         no: row.no + 1,
         name: "bar",

--- a/src/cursors/row.rs
+++ b/src/cursors/row.rs
@@ -99,7 +99,10 @@ impl<T> RowCursor<T> {
                         }
                     }
                     slice = super::workaround_51132(self.bytes.slice());
-                    rowbinary::deserialize_rbwnat::<T>(&mut slice, self.row_metadata.as_ref())
+                    rowbinary::deserialize_with_validation::<T>(
+                        &mut slice,
+                        self.row_metadata.as_ref(),
+                    )
                 } else {
                     slice = super::workaround_51132(self.bytes.slice());
                     rowbinary::deserialize_row_binary::<T>(&mut slice)

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -53,9 +53,8 @@ impl<T> Inserter<T>
 where
     T: Row,
 {
-    // TODO: (breaking change) remove `Result`.
-    pub(crate) fn new(client: &Client, table: &str) -> Result<Self> {
-        Ok(Self {
+    pub(crate) fn new(client: &Client, table: &str) -> Self {
+        Self {
             client: client.clone(),
             table: table.into(),
             max_bytes: u64::MAX,
@@ -66,7 +65,7 @@ where
             ticks: Ticks::default(),
             pending: Quantities::ZERO,
             in_transaction: false,
-        })
+        }
     }
 
     /// See [`Insert::with_timeouts()`].
@@ -215,12 +214,12 @@ where
     /// # Panics
     /// If called after the previous call that returned an error.
     #[inline]
-    pub fn write(&mut self, row: &T) -> Result<()>
+    pub async fn write(&mut self, row: &T) -> Result<()>
     where
         T: Serialize,
     {
         if self.insert.is_none() {
-            self.init_insert()?;
+            self.init_insert().await?;
         }
 
         match self.insert.as_mut().unwrap().do_write(row) {
@@ -278,7 +277,7 @@ where
     }
 
     async fn insert(&mut self) -> Result<()> {
-        if let Some(insert) = self.insert.take() {
+        if let Some(mut insert) = self.insert.take() {
             insert.end().await?;
         }
         Ok(())
@@ -286,11 +285,11 @@ where
 
     #[cold]
     #[inline(never)]
-    fn init_insert(&mut self) -> Result<()> {
+    async fn init_insert(&mut self) -> Result<()> {
         debug_assert!(self.insert.is_none());
         debug_assert_eq!(self.pending, Quantities::ZERO);
 
-        let mut new_insert: Insert<T> = self.client.insert(&self.table)?;
+        let mut new_insert: Insert<T> = self.client.insert(&self.table).await?;
         new_insert.set_timeouts(self.send_timeout, self.end_timeout);
         self.insert = Some(new_insert);
         Ok(())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,6 +7,7 @@ extern crate static_assertions;
 
 pub use self::{compression::Compression, row::Row, row::RowKind};
 use self::{error::Result, http_client::HttpClient};
+use crate::row_metadata::{get_row_metadata, RowMetadataCache};
 pub use clickhouse_derive::Row;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 
@@ -48,6 +49,7 @@ pub struct Client {
     headers: HashMap<String, String>,
     products_info: Vec<ProductInfo>,
     validation: bool,
+    row_metadata_cache: Arc<RowMetadataCache>,
 
     #[cfg(feature = "test-util")]
     mocked: bool,
@@ -106,6 +108,7 @@ impl Client {
             headers: HashMap::new(),
             products_info: Vec::default(),
             validation: true,
+            row_metadata_cache: Arc::new(RowMetadataCache::default()),
             #[cfg(feature = "test-util")]
             mocked: false,
         }
@@ -303,15 +306,33 @@ impl Client {
 
     /// Starts a new INSERT statement.
     ///
+    /// # Validation
+    ///
+    /// If validation is enabled (default), `RowBinaryWithNamesAndTypes` input format is used.
+    /// When [`Client::insert`] method is called for this `table` for the first time,
+    /// it will fetch the table schema from the server, allowing to validate the serialized rows,
+    /// as well as write the names and types of the columns in the request header.
+    ///
+    /// Fetching the schema will happen only once per `table`,
+    /// as the schema is cached by the client internally.
+    ///
+    /// With disabled validation, the schema is not fetched,
+    /// and the rows serialized with `RowBinary` input format.
+    ///
     /// # Panics
+    ///
     /// If `T` has unnamed fields, e.g. tuples.
-    pub fn insert<T: Row>(&self, table: &str) -> Result<insert::Insert<T>> {
-        insert::Insert::new(self, table)
+    pub async fn insert<T: Row>(&self, table: &str) -> Result<insert::Insert<T>> {
+        if self.get_validation() {
+            let metadata = get_row_metadata::<T>(self, table).await?;
+            return Ok(insert::Insert::new(self, table, Some(metadata)));
+        }
+        Ok(insert::Insert::new(self, table, None))
     }
 
-    /// Creates an inserter to perform multiple INSERTs.
+    /// Creates an inserter to perform multiple INSERT statements.
     #[cfg(feature = "inserter")]
-    pub fn inserter<T: Row>(&self, table: &str) -> Result<inserter::Inserter<T>> {
+    pub fn inserter<T: Row>(&self, table: &str) -> inserter::Inserter<T> {
         inserter::Inserter::new(self, table)
     }
 

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -37,7 +37,7 @@ pub(crate) fn deserialize_row_binary<'data, 'cursor, T: Deserialize<'data> + Row
 /// Similar to [`deserialize_row_binary`], but uses [`RowMetadata`]
 /// parsed from `RowBinaryWithNamesAndTypes` header to validate the data types.
 /// This is used when [`crate::Row`] validation is enabled in the client (default).
-pub(crate) fn deserialize_rbwnat<'data, 'cursor, T: Deserialize<'data> + Row>(
+pub(crate) fn deserialize_with_validation<'data, 'cursor, T: Deserialize<'data> + Row>(
     input: &mut &'data [u8],
     metadata: Option<&'cursor RowMetadata>,
 ) -> Result<T> {

--- a/src/rowbinary/mod.rs
+++ b/src/rowbinary/mod.rs
@@ -1,6 +1,7 @@
-pub(crate) use de::deserialize_rbwnat;
 pub(crate) use de::deserialize_row_binary;
-pub(crate) use ser::serialize_into;
+pub(crate) use de::deserialize_with_validation;
+pub(crate) use ser::serialize_row_binary;
+pub(crate) use ser::serialize_with_validation;
 
 pub(crate) mod validation;
 

--- a/src/rowbinary/ser.rs
+++ b/src/rowbinary/ser.rs
@@ -6,9 +6,24 @@ use serde::{
 };
 
 use crate::error::{Error, Result};
+use crate::row_metadata::RowMetadata;
 
-/// Serializes `value` using the RowBinary format and writes to `buffer`.
-pub(crate) fn serialize_into(buffer: impl BufMut, value: &impl Serialize) -> Result<()> {
+/// Serializes `value` using the `RowBinary` format and writes to `buffer`.
+pub(crate) fn serialize_row_binary(buffer: impl BufMut, value: &impl Serialize) -> Result<()> {
+    let mut serializer = RowBinarySerializer { buffer };
+    value.serialize(&mut serializer)?;
+    Ok(())
+}
+
+/// Serializes `value` using the `RowBinary` format and writes to `buffer`.
+/// Additionally, it will perform validation against the provided `row_metadata`,
+/// similarly to how [`crate::rowbinary::deserialize_with_validation`] works.
+/// `RowBinaryWithNamesAndTypes` header is expected to be written by [`crate::insert::Insert`].
+pub(crate) fn serialize_with_validation(
+    buffer: impl BufMut,
+    value: &impl Serialize,
+    _row_metadata: &'_ RowMetadata,
+) -> Result<()> {
     let mut serializer = RowBinarySerializer { buffer };
     value.serialize(&mut serializer)?;
     Ok(())

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -139,7 +139,7 @@ fn sample_serialized() -> Vec<u8> {
 #[test]
 fn it_serializes() {
     let mut actual = Vec::new();
-    super::serialize_into(&mut actual, &sample()).unwrap();
+    super::serialize_row_binary(&mut actual, &sample()).unwrap();
     assert_eq!(actual, sample_serialized());
 }
 

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -46,7 +46,7 @@ where
 {
     let mut buffer = Vec::with_capacity(BUFFER_INITIAL_CAPACITY);
     for row in rows {
-        rowbinary::serialize_into(&mut buffer, &row).expect("failed to serialize");
+        rowbinary::serialize_row_binary(&mut buffer, &row).expect("failed to serialize");
     }
     Thunk(Response::new(buffer.into()))
 }

--- a/tests/it/chrono.rs
+++ b/tests/it/chrono.rs
@@ -88,7 +88,7 @@ async fn datetime() {
         dt64ns_opt: Some(dt_ns),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 
@@ -146,7 +146,7 @@ async fn date() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
 
     let dates = generate_dates(1970..2149, 100);
     for &date in &dates {
@@ -199,7 +199,7 @@ async fn date32() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
 
     let dates = generate_dates(1925..2283, 100); // TODO: 1900..=2299 for newer versions.
     for &date in &dates {

--- a/tests/it/compression.rs
+++ b/tests/it/compression.rs
@@ -5,7 +5,7 @@ use crate::{create_simple_table, SimpleRow};
 async fn check(client: Client) {
     create_simple_table(&client, "test").await;
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for i in 0..200_000 {
         insert.write(&SimpleRow::new(i, "foo")).await.unwrap();
     }

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -67,7 +67,7 @@ async fn deferred_lz4() {
 
     // Due to compression we need more complex test here: write a lot of big parts.
     for i in 0..part_count {
-        let mut insert = client.insert("test").unwrap();
+        let mut insert = client.insert("test").await.unwrap();
 
         for j in 0..part_size {
             let row = Row {

--- a/tests/it/cursor_stats.rs
+++ b/tests/it/cursor_stats.rs
@@ -5,7 +5,7 @@ use crate::{create_simple_table, SimpleRow};
 async fn check(client: Client, expected_ratio: f64) {
     create_simple_table(&client, "test").await;
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for i in 0..1_000 {
         insert.write(&SimpleRow::new(i, "foobar")).await.unwrap();
     }

--- a/tests/it/insert.rs
+++ b/tests/it/insert.rs
@@ -16,6 +16,7 @@ async fn keeps_client_options() {
 
     let mut insert = client
         .insert(table_name)
+        .await
         .unwrap()
         .with_option(insert_setting_name, insert_setting_value)
         .with_option("query_id", &query_id);
@@ -68,6 +69,7 @@ async fn overrides_client_options() {
 
     let mut insert = client
         .insert(table_name)
+        .await
         .unwrap()
         .with_option(setting_name, override_value)
         .with_option("query_id", &query_id);
@@ -112,8 +114,9 @@ async fn empty_insert() {
     let client = prepare_database!();
     create_simple_table(&client, table_name).await;
 
-    let insert = client
+    let mut insert = client
         .insert::<SimpleRow>(table_name)
+        .await
         .unwrap()
         .with_option("query_id", &query_id);
 
@@ -164,6 +167,7 @@ async fn rename_insert() {
 
     let mut insert = client
         .insert(table_name)
+        .await
         .unwrap()
         .with_option("query_id", &query_id);
 

--- a/tests/it/int128.rs
+++ b/tests/it/int128.rs
@@ -44,7 +44,7 @@ async fn u128() {
         },
     ];
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for row in &original_rows {
         insert.write(row).await.unwrap();
     }
@@ -103,7 +103,7 @@ async fn i128() {
         },
     ];
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for row in &original_rows {
         insert.write(row).await.unwrap();
     }

--- a/tests/it/ip.rs
+++ b/tests/it/ip.rs
@@ -40,7 +40,7 @@ async fn smoke() {
         ipv6_opt: Some(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0xafc8, 0x10, 0x1)),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/nested.rs
+++ b/tests/it/nested.rs
@@ -38,7 +38,7 @@ async fn smoke() {
         items_count: vec![1, 5],
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -26,7 +26,7 @@ async fn smoke() {
         .unwrap();
 
     // Write to the table.
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for i in 0..1000 {
         insert.write(&MyRow { no: i, name: "foo" }).await.unwrap();
     }
@@ -73,7 +73,7 @@ async fn fetch_one_and_optional() {
         n: String,
     }
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&Row { n: "foo".into() }).await.unwrap();
     insert.write(&Row { n: "bar".into() }).await.unwrap();
     insert.end().await.unwrap();
@@ -165,7 +165,7 @@ async fn big_borrowed_str() {
 
     let long_string = "A".repeat(10000);
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert
         .write(&MyRow {
             no: 0,
@@ -201,7 +201,7 @@ async fn all_floats() {
         f: f64,
     }
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&Row { no: 0, f: 42.5 }).await.unwrap();
     insert.write(&Row { no: 1, f: 43.5 }).await.unwrap();
     insert.end().await.unwrap();

--- a/tests/it/rbwnat.rs
+++ b/tests/it/rbwnat.rs
@@ -758,7 +758,7 @@ async fn enums() {
         },
     ];
 
-    let mut insert = client.insert(table_name).unwrap();
+    let mut insert = client.insert(table_name).await.unwrap();
     for row in &expected {
         insert.write(row).await.unwrap()
     }
@@ -1349,7 +1349,7 @@ async fn issue_109_1() {
         .fetch_all::<Data>()
         .await
         .unwrap();
-    let mut insert = client.insert("issue_109").unwrap();
+    let mut insert = client.insert("issue_109").await.unwrap();
     for (id, elem) in data.iter().enumerate() {
         let elem = Data {
             en_id: format!("ABC-{}", id),

--- a/tests/it/time.rs
+++ b/tests/it/time.rs
@@ -80,7 +80,7 @@ async fn datetime() {
         dt64ns_opt: Some(datetime!(2022-11-13 15:27:42.123456789 UTC)),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 
@@ -138,7 +138,7 @@ async fn date() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
 
     let dates = generate_dates(1970..2149, 100);
     for &date in &dates {
@@ -191,7 +191,7 @@ async fn date32() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
 
     let dates = generate_dates(1925..2283, 100); // TODO: 1900..=2299 for newer versions.
     for &date in &dates {

--- a/tests/it/user_agent.rs
+++ b/tests/it/user_agent.rs
@@ -40,7 +40,7 @@ async fn assert_queries_user_agents(client: &Client, table_name: &str, expected_
 
     create_simple_table(client, table_name).await;
 
-    let mut insert = client.insert(table_name).unwrap();
+    let mut insert = client.insert(table_name).await.unwrap();
     insert.write(&row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/uuid.rs
+++ b/tests/it/uuid.rs
@@ -38,7 +38,7 @@ async fn smoke() {
         uuid_opt: Some(uuid),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/variant.rs
+++ b/tests/it/variant.rs
@@ -90,7 +90,7 @@ async fn variant_data_type() {
     let rows = vars.map(|var| MyRow { var });
 
     // Write to the table.
-    let mut insert = client.insert("test_var").unwrap();
+    let mut insert = client.insert("test_var").await.unwrap();
     for row in &rows {
         insert.write(row).await.unwrap();
     }

--- a/tests/it/watch.rs
+++ b/tests/it/watch.rs
@@ -24,7 +24,7 @@ async fn create_table(client: &Client) {
 }
 
 async fn insert_into_table(client: &Client, rows: &[MyRow]) {
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert("test").await.unwrap();
     for row in rows {
         insert.write(row).await.unwrap();
     }


### PR DESCRIPTION
## Summary

WIP.

Temporarily on top of #221, will be rebased once that PR is squashed.

Implements RBWNAT support for insert and inserter.

Unfortunately, there will be quite a lot of breaking changes. Specifically, we absolutely need make `Insert::new` async, so we can properly fetch the schema. This also implies making `Inserter::write` async too (but at least this is aligned with how `insert` works already). On a flip side, useless `Result` types from the constructors are now removed.

Current progress:

- [x] RowMetadata cache
- [x] Insert support
- [x] Inserter support
- [x] Writing RBWNAT header
- [ ] Serializer validation calls
- [ ] CHANGELOG
- [ ] README
- [ ] Tests

Closes #199 (full list of issues TBD)