### PR TITLE
Redesign the support of borrowed rows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,14 @@ jobs:
         run: |
           cargo test cloud_ --features rustls-tls -- --nocapture
           cargo test https_errors -- --nocapture
+
+  miri:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: rustup toolchain install nightly --component miri
+      - run: rustup override set nightly
+      - run: rustup show active-toolchain -v
+      - run: cargo miri setup
+      - run: cargo miri test --all-features -- _miri

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,10 +97,11 @@ jobs:
           down-flags: '--volumes'
 
       - run: rustup show active-toolchain -v
-      - run: cargo test
-      - run: cargo test --no-default-features
-      - run: cargo test --features uuid,time
-      - run: cargo test --all-features
+      # TODO: --workspace won't be required after splitting workspace and the main crate
+      - run: cargo test --workspace
+      - run: cargo test --workspace --no-default-features
+      - run: cargo test --workspace --features uuid,time
+      - run: cargo test --workspace --all-features
 
       - name: Run tests with ClickHouse Cloud
         env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,3 +161,4 @@ uuid = { version = "1", features = ["v4", "serde"] }
 time = { version = "0.3.17", features = ["macros", "rand", "parsing"] }
 fixnum = { version = "0.9.2", features = ["serde", "i32", "i64", "i128"] }
 rand = { version = "0.9", features = ["small_rng"] }
+trybuild = "1.0"

--- a/benches/common_select.rs
+++ b/benches/common_select.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 
 use clickhouse::query::RowCursor;
-use clickhouse::{Client, Compression, ReadRow, Row};
+use clickhouse::{Client, Compression, Row, RowRead};
 use std::time::{Duration, Instant};
 
 pub(crate) trait WithId {
@@ -10,7 +10,7 @@ pub(crate) trait WithId {
 pub(crate) trait WithAccessType {
     const ACCESS_TYPE: &'static str;
 }
-pub(crate) trait BenchmarkRow: for<'a> ReadRow<Value<'a>: WithId> + WithAccessType {}
+pub(crate) trait BenchmarkRow: for<'a> RowRead<Value<'a>: WithId> + WithAccessType {}
 
 #[macro_export]
 macro_rules! impl_benchmark_row {

--- a/benches/mocked_insert.rs
+++ b/benches/mocked_insert.rs
@@ -51,7 +51,7 @@ async fn run_insert(client: Client, addr: SocketAddr, iters: u64) -> Result<Dura
     let _server = common::start_server(addr, serve).await;
 
     let start = Instant::now();
-    let mut insert = client.insert("table")?;
+    let mut insert = client.insert::<SomeRow>("table")?;
 
     for _ in 0..iters {
         insert.write(&SomeRow::sample()).await?;
@@ -70,7 +70,7 @@ async fn run_inserter<const WITH_PERIOD: bool>(
     let _server = common::start_server(addr, serve).await;
 
     let start = Instant::now();
-    let mut inserter = client.inserter("table")?.with_max_rows(iters);
+    let mut inserter = client.inserter::<SomeRow>("table")?.with_max_rows(iters);
 
     if WITH_PERIOD {
         // Just to measure overhead, not to actually use it.

--- a/benches/select_market_data.rs
+++ b/benches/select_market_data.rs
@@ -71,7 +71,7 @@ async fn prepare_data() {
         return;
     }
 
-    let mut insert = client.insert("l2_book_log").unwrap();
+    let mut insert = client.insert::<L2Update>("l2_book_log").unwrap();
 
     for i in 0..10_000_000 {
         insert

--- a/benches/select_nyc_taxi_data.rs
+++ b/benches/select_nyc_taxi_data.rs
@@ -74,7 +74,7 @@ struct TripSmallMapAccess {
 impl_benchmark_row!(TripSmallSeqAccess, trip_id, "seq");
 impl_benchmark_row!(TripSmallMapAccess, trip_id, "map");
 
-async fn bench<'a, T: BenchmarkRow<'a>>(compression: Compression, validation: bool) {
+async fn bench<T: BenchmarkRow>(compression: Compression, validation: bool) {
     let stats = do_select_bench::<T>(
         "SELECT * FROM nyc_taxi.trips_small ORDER BY trip_id DESC",
         compression,

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -18,3 +18,7 @@ proc-macro2 = "1.0"
 syn = "2.0"
 quote = "1.0"
 serde_derive_internals = "0.29.1"
+
+[dev-dependencies]
+insta = "1.43.1"
+prettyplease = "0.2.35"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -96,7 +96,7 @@ fn row_impl(input: DeriveInput) -> Result<TokenStream> {
             const NAME: &'static str = stringify!(#name);
             const COLUMN_NAMES: &'static [&'static str] = #column_names;
             const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-            const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+            const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
 
             type Value<'__v> = #value;
         }

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -4,10 +4,13 @@ use serde_derive_internals::{
     attr::{Container, Default as SerdeDefault, Field},
     Ctxt,
 };
-use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Fields, Lifetime};
+use syn::{parse_macro_input, Data, DataStruct, DeriveInput, Error, Fields, Lifetime, Result};
 
-fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStream {
-    match &data.fields {
+#[cfg(test)]
+mod tests;
+
+fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> Result<TokenStream> {
+    Ok(match &data.fields {
         Fields::Named(fields) => {
             let rename_rule = container.rename_all_rules().deserialize;
             let column_names_iter = fields
@@ -29,8 +32,8 @@ fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStr
         Fields::Unnamed(_) => {
             quote! { &[] }
         }
-        Fields::Unit => panic!("`Row` cannot be derived for unit structs"),
-    }
+        Fields::Unit => unreachable!("checked by the caller"),
+    })
 }
 
 // TODO: support wrappers `Wrapper(Inner)` and `Wrapper<T>(T)`.
@@ -39,34 +42,55 @@ fn column_names(data: &DataStruct, cx: &Ctxt, container: &Container) -> TokenStr
 #[proc_macro_derive(Row)]
 pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let input = parse_macro_input!(input as DeriveInput);
+    row_impl(input)
+        .unwrap_or_else(Error::into_compile_error)
+        .into()
+}
 
+fn row_impl(input: DeriveInput) -> Result<TokenStream> {
     let cx = Ctxt::new();
     let container = Container::from_ast(&cx, &input);
     let name = input.ident;
 
-    let column_names = match &input.data {
+    let result = match &input.data {
+        Data::Struct(data) if data.fields.is_empty() => {
+            let reason = "`Row` cannot be derived for unit or empty structs";
+            Err(Error::new(name.span(), reason))
+        }
         Data::Struct(data) => column_names(data, &cx, &container),
-        Data::Enum(_) | Data::Union(_) => panic!("`Row` can be derived only for structs"),
+        Data::Enum(_) | Data::Union(_) => {
+            let reason = "`Row` can only be derived for structs";
+            Err(Error::new(name.span(), reason))
+        }
     };
 
-    // TODO: do something more clever?
-    cx.check().expect("derive context error");
+    cx.check()?;
+    let column_names = result?;
 
-    let is_borrowed = input.generics.lifetimes().next().is_some();
-    let value = if is_borrowed {
-        let mut cloned = input.generics.clone();
-        let param = cloned.lifetimes_mut().next().unwrap();
-        param.lifetime = Lifetime::new("'__v", Span::call_site());
-        let ty_generics = cloned.split_for_impl().1;
-        quote! { #name #ty_generics }
-    } else {
-        quote! { Self }
+    let value = match input.generics.lifetimes().count() {
+        // An owned row: `struct Row { .. }`
+        0 => quote! { Self },
+        // A borrowed row: `struct Row<'a> { .. }`
+        1 => {
+            // Replace the lifetime with `__v` to set `Value<'__v> = ..`.
+            let mut cloned = input.generics.clone();
+            let param = cloned.lifetimes_mut().next().unwrap();
+            param.lifetime = Lifetime::new("'__v", Span::call_site());
+            let ty_generics = cloned.split_for_impl().1;
+            quote! { #name #ty_generics }
+        }
+        // A borrowed row with multiple lifetimes: `struct Row<'a, 'b> { .. }`
+        _ => {
+            let lt = input.generics.lifetimes().nth(1).unwrap();
+            let reason = "`Row` cannot be derived for structs with multiple lifetimes";
+            return Err(Error::new(lt.lifetime.span(), reason));
+        }
     };
 
     let (impl_generics, ty_generics, where_clause) = input.generics.split_for_impl();
 
     // TODO: replace `clickhouse` with `::clickhouse` here.
-    let expanded = quote! {
+    Ok(quote! {
         #[automatically_derived]
         impl #impl_generics clickhouse::Row for #name #ty_generics #where_clause {
             const NAME: &'static str = stringify!(#name);
@@ -76,7 +100,5 @@ pub fn row(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
             type Value<'__v> = #value;
         }
-    };
-
-    proc_macro::TokenStream::from(expanded)
+    })
 }

--- a/derive/src/tests/cases.rs
+++ b/derive/src/tests/cases.rs
@@ -1,0 +1,121 @@
+//! # Snapshot tests for `Row` derive macro.
+//!
+//! - This module contains happy path tests. For failures, see `tests/ui/`.
+//! - These tests are supposed to be used as intermediate checks for complex
+//!   code generation, not as a final integration tests.
+
+use super::render;
+
+#[test]
+fn simple_owned_row() {
+    render! {
+        #[derive(Row)]
+        struct Sample {
+            a: i32,
+            b: String,
+        }
+    };
+}
+
+#[test]
+fn generic_owned_row() {
+    render! {
+        #[derive(Row)]
+        struct Sample<T> {
+            a: i32,
+            b: T,
+        }
+    };
+
+    render! {
+        #[derive(Row)]
+        struct Sample<A, B> {
+            a: A,
+            b: B,
+        }
+    };
+
+    render! {
+        #[derive(Row)]
+        struct Sample<T> where T: Clone {
+            a: i32,
+            b: T,
+        }
+    };
+}
+
+#[test]
+fn simple_borrowed_row() {
+    render! {
+        #[derive(Row)]
+        struct Sample<'a> {
+            a: i32,
+            b: &'a str,
+        }
+    };
+}
+
+#[test]
+fn generic_borrowed_row() {
+    render! {
+        #[derive(Row)]
+        struct Sample<'a, T> {
+            a: i32,
+            b: &'a T,
+        }
+    };
+
+    render! {
+        #[derive(Row)]
+        struct Sample<'a, A, B> {
+            a: A,
+            b: &'a B,
+        }
+    };
+
+    render! {
+        #[derive(Row)]
+        struct Sample<'a, T> where T: Clone {
+            a: i32,
+            b: &'a T,
+        }
+    };
+}
+
+#[test]
+fn serde_rename() {
+    render! {
+        #[derive(Row)]
+        struct Sample {
+            a: i32,
+            #[serde(rename = "items.a")]
+            items_a: Vec<String>,
+            #[serde(rename = "items.b")]
+            items_b: Vec<u32>,
+        }
+    };
+}
+
+#[test]
+fn serde_skip_serializing() {
+    render! {
+        #[derive(Row)]
+        struct Sample {
+            a: u32,
+            #[serde(skip_serializing)]
+            b: u32,
+        }
+    };
+}
+
+#[test]
+fn serde_skip_deserializing() {
+    render! {
+        #[derive(Row)]
+        struct Sample {
+            a: u32,
+            #[serde(skip_deserializing)]
+            b: u32,
+        }
+    };
+}

--- a/derive/src/tests/mod.rs
+++ b/derive/src/tests/mod.rs
@@ -1,0 +1,34 @@
+use proc_macro2::TokenStream;
+use std::str::FromStr;
+
+mod cases;
+
+macro_rules! render {
+    ($($input:tt)*) => {
+        ::insta::with_settings!({
+            prepend_module_to_snapshot => false,
+            omit_expression => true,
+        }, {
+            let input = ::std::stringify!($($input)*);
+            let output = $crate::tests::_do_render(input);
+            ::insta::assert_snapshot!(output);
+        })
+    };
+}
+
+fn _do_render(input_ugly: &str) -> String {
+    let input_file_ast = syn::parse_file(input_ugly).expect("failed to parse input as file");
+    let input_pretty = prettyplease::unparse(&input_file_ast);
+    let input_tokens = TokenStream::from_str(input_ugly).expect("invalid input tokens");
+    let input_derive_ast = syn::parse2(input_tokens).expect("failed to parse input");
+
+    let output_tokens = crate::row_impl(input_derive_ast)
+        .expect("failed to generate `impl Row`, use tests/ui for such tests");
+    let output_ugly = output_tokens.to_string();
+    let output_file_ast = syn::parse_file(&output_ugly).expect("failed to parse output as file");
+    let output_pretty = prettyplease::unparse(&output_file_ast);
+
+    format!("\n{input_pretty}\n/****** GENERATED ******/\n{output_pretty}")
+}
+
+use render;

--- a/derive/src/tests/snapshots/generic_borrowed_row-2.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row-2.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<'a, A, B> {
+    a: A,
+    b: &'a B,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<'a, A, B> clickhouse::Row for Sample<'a, A, B> {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Sample<'__v, A, B>;
+}

--- a/derive/src/tests/snapshots/generic_borrowed_row-2.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row-2.snap
@@ -13,6 +13,6 @@ impl<'a, A, B> clickhouse::Row for Sample<'a, A, B> {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Sample<'__v, A, B>;
 }

--- a/derive/src/tests/snapshots/generic_borrowed_row-3.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row-3.snap
@@ -1,0 +1,24 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<'a, T>
+where
+    T: Clone,
+{
+    a: i32,
+    b: &'a T,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<'a, T> clickhouse::Row for Sample<'a, T>
+where
+    T: Clone,
+{
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Sample<'__v, T>;
+}

--- a/derive/src/tests/snapshots/generic_borrowed_row-3.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row-3.snap
@@ -19,6 +19,6 @@ where
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Sample<'__v, T>;
 }

--- a/derive/src/tests/snapshots/generic_borrowed_row.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<'a, T> {
+    a: i32,
+    b: &'a T,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<'a, T> clickhouse::Row for Sample<'a, T> {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Sample<'__v, T>;
+}

--- a/derive/src/tests/snapshots/generic_borrowed_row.snap
+++ b/derive/src/tests/snapshots/generic_borrowed_row.snap
@@ -13,6 +13,6 @@ impl<'a, T> clickhouse::Row for Sample<'a, T> {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Sample<'__v, T>;
 }

--- a/derive/src/tests/snapshots/generic_owned_row-2.snap
+++ b/derive/src/tests/snapshots/generic_owned_row-2.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<A, B> {
+    a: A,
+    b: B,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<A, B> clickhouse::Row for Sample<A, B> {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/generic_owned_row-2.snap
+++ b/derive/src/tests/snapshots/generic_owned_row-2.snap
@@ -13,6 +13,6 @@ impl<A, B> clickhouse::Row for Sample<A, B> {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/generic_owned_row-3.snap
+++ b/derive/src/tests/snapshots/generic_owned_row-3.snap
@@ -19,6 +19,6 @@ where
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/generic_owned_row-3.snap
+++ b/derive/src/tests/snapshots/generic_owned_row-3.snap
@@ -1,0 +1,24 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<T>
+where
+    T: Clone,
+{
+    a: i32,
+    b: T,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<T> clickhouse::Row for Sample<T>
+where
+    T: Clone,
+{
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/generic_owned_row.snap
+++ b/derive/src/tests/snapshots/generic_owned_row.snap
@@ -13,6 +13,6 @@ impl<T> clickhouse::Row for Sample<T> {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/generic_owned_row.snap
+++ b/derive/src/tests/snapshots/generic_owned_row.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<T> {
+    a: i32,
+    b: T,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<T> clickhouse::Row for Sample<T> {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/serde_rename.snap
+++ b/derive/src/tests/snapshots/serde_rename.snap
@@ -1,0 +1,21 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample {
+    a: i32,
+    #[serde(rename = "items.a")]
+    items_a: Vec<String>,
+    #[serde(rename = "items.b")]
+    items_b: Vec<u32>,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl clickhouse::Row for Sample {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "items.a", "items.b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/serde_rename.snap
+++ b/derive/src/tests/snapshots/serde_rename.snap
@@ -16,6 +16,6 @@ impl clickhouse::Row for Sample {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "items.a", "items.b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/serde_skip_deserializing.snap
+++ b/derive/src/tests/snapshots/serde_skip_deserializing.snap
@@ -14,6 +14,6 @@ impl clickhouse::Row for Sample {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/serde_skip_deserializing.snap
+++ b/derive/src/tests/snapshots/serde_skip_deserializing.snap
@@ -1,0 +1,19 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample {
+    a: u32,
+    #[serde(skip_deserializing)]
+    b: u32,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl clickhouse::Row for Sample {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/serde_skip_serializing.snap
+++ b/derive/src/tests/snapshots/serde_skip_serializing.snap
@@ -14,6 +14,6 @@ impl clickhouse::Row for Sample {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/derive/src/tests/snapshots/serde_skip_serializing.snap
+++ b/derive/src/tests/snapshots/serde_skip_serializing.snap
@@ -1,0 +1,19 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample {
+    a: u32,
+    #[serde(skip_serializing)]
+    b: u32,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl clickhouse::Row for Sample {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/simple_borrowed_row.snap
+++ b/derive/src/tests/snapshots/simple_borrowed_row.snap
@@ -13,6 +13,6 @@ impl<'a> clickhouse::Row for Sample<'a> {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Sample<'__v>;
 }

--- a/derive/src/tests/snapshots/simple_borrowed_row.snap
+++ b/derive/src/tests/snapshots/simple_borrowed_row.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample<'a> {
+    a: i32,
+    b: &'a str,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl<'a> clickhouse::Row for Sample<'a> {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Sample<'__v>;
+}

--- a/derive/src/tests/snapshots/simple_owned_row.snap
+++ b/derive/src/tests/snapshots/simple_owned_row.snap
@@ -1,0 +1,18 @@
+---
+source: derive/src/tests/cases.rs
+---
+#[derive(Row)]
+struct Sample {
+    a: i32,
+    b: String,
+}
+
+/****** GENERATED ******/
+#[automatically_derived]
+impl clickhouse::Row for Sample {
+    const NAME: &'static str = stringify!(Sample);
+    const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
+    const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
+    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    type Value<'__v> = Self;
+}

--- a/derive/src/tests/snapshots/simple_owned_row.snap
+++ b/derive/src/tests/snapshots/simple_owned_row.snap
@@ -13,6 +13,6 @@ impl clickhouse::Row for Sample {
     const NAME: &'static str = stringify!(Sample);
     const COLUMN_NAMES: &'static [&'static str] = &["a", "b"];
     const COLUMN_COUNT: usize = <Self as clickhouse::Row>::COLUMN_NAMES.len();
-    const KIND: clickhouse::RowKind = clickhouse::RowKind::Struct;
+    const KIND: clickhouse::_priv::RowKind = clickhouse::_priv::RowKind::Struct;
     type Value<'__v> = Self;
 }

--- a/examples/async_insert.rs
+++ b/examples/async_insert.rs
@@ -40,7 +40,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<Event>(table_name)?;
     insert
         .write(&Event {
             timestamp: now(),

--- a/examples/clickhouse_cloud.rs
+++ b/examples/clickhouse_cloud.rs
@@ -42,7 +42,7 @@ async fn main() -> clickhouse::error::Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<Data>(table_name)?;
     insert
         .write(&Data {
             id: 42,

--- a/examples/data_types_derive_containers.rs
+++ b/examples/data_types_derive_containers.rs
@@ -37,7 +37,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<Row>(table_name)?;
     insert.write(&Row::new()).await?;
     insert.end().await?;
 

--- a/examples/data_types_derive_simple.rs
+++ b/examples/data_types_derive_simple.rs
@@ -80,7 +80,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<Row>(table_name)?;
     insert.write(&Row::new()).await?;
     insert.end().await?;
 

--- a/examples/data_types_new_json.rs
+++ b/examples/data_types_new_json.rs
@@ -49,7 +49,7 @@ async fn main() -> Result<()> {
         .to_string(),
     };
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<Row>(table_name)?;
     insert.write(&row).await?;
     insert.end().await?;
 

--- a/examples/data_types_variant.rs
+++ b/examples/data_types_variant.rs
@@ -42,7 +42,7 @@ async fn main() -> Result<()> {
         .execute()
         .await?;
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<MyRow>(table_name)?;
     let rows_to_insert = get_rows();
     for row in rows_to_insert {
         insert.write(&row).await?;

--- a/examples/enums.rs
+++ b/examples/enums.rs
@@ -50,7 +50,7 @@ async fn main() -> Result<()> {
         Error = 4,
     }
 
-    let mut insert = client.insert("event_log")?;
+    let mut insert = client.insert::<Event>("event_log")?;
     insert
         .write(&Event {
             timestamp: now(),

--- a/examples/inserter.rs
+++ b/examples/inserter.rs
@@ -22,7 +22,7 @@ struct MyRow {
 // In other words, this pattern is applicable for ETL-like tasks.
 async fn dense(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
     let mut inserter = client
-        .inserter(TABLE_NAME)?
+        .inserter::<MyRow>(TABLE_NAME)?
         // We limit the number of rows to be inserted in a single `INSERT` statement.
         // We use small value (100) for the example only.
         // See documentation of `with_max_rows` for details.
@@ -47,7 +47,7 @@ async fn dense(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
 // Some rows are arriving one by one with delay, some batched.
 async fn sparse(client: &Client, mut rx: Receiver<u32>) -> Result<()> {
     let mut inserter = client
-        .inserter(TABLE_NAME)?
+        .inserter::<MyRow>(TABLE_NAME)?
         // Slice the stream into chunks (one `INSERT` per chunk) by time.
         // See documentation of `with_period` for details.
         .with_period(Some(Duration::from_millis(100)))

--- a/examples/mock.rs
+++ b/examples/mock.rs
@@ -19,7 +19,7 @@ async fn make_select(client: &Client) -> Result<Vec<SomeRow>> {
 }
 
 async fn make_insert(client: &Client, data: &[SomeRow]) -> Result<()> {
-    let mut insert = client.insert("who cares")?;
+    let mut insert = client.insert::<SomeRow>("who cares")?;
     for row in data {
         insert.write(row).await?;
     }

--- a/examples/session_id.rs
+++ b/examples/session_id.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
         i: i32,
     }
 
-    let mut insert = client.insert(table_name)?;
+    let mut insert = client.insert::<MyRow>(table_name)?;
     insert.write(&MyRow { i: 42 }).await?;
     insert.end().await?;
 

--- a/examples/usage.rs
+++ b/examples/usage.rs
@@ -29,7 +29,7 @@ async fn ddl(client: &Client) -> Result<()> {
 }
 
 async fn insert(client: &Client) -> Result<()> {
-    let mut insert = client.insert("some")?;
+    let mut insert = client.insert::<MyRow<'_>>("some")?;
     for i in 0..1000 {
         insert.write(&MyRow { no: i, name: "foo" }).await?;
     }
@@ -42,7 +42,7 @@ async fn insert(client: &Client) -> Result<()> {
 #[cfg(feature = "inserter")]
 async fn inserter(client: &Client) -> Result<()> {
     let mut inserter = client
-        .inserter("some")?
+        .inserter::<MyRow<'_>>("some")?
         .with_max_rows(100_000)
         .with_period(Some(std::time::Duration::from_secs(15)));
 

--- a/src/bytes_ext.rs
+++ b/src/bytes_ext.rs
@@ -1,32 +1,27 @@
 use bytes::{Bytes, BytesMut};
+use std::cell::{Cell, UnsafeCell};
 
 #[derive(Default)]
 pub(crate) struct BytesExt {
-    bytes: Bytes,
-    cursor: usize,
+    bytes: UnsafeCell<Bytes>,
+    cursor: Cell<usize>,
 }
 
 impl BytesExt {
     #[inline(always)]
     pub(crate) fn slice(&self) -> &[u8] {
-        &self.bytes[self.cursor..]
+        &self.bytes()[self.cursor.get()..]
     }
 
     #[inline(always)]
     pub(crate) fn remaining(&self) -> usize {
-        self.bytes.len() - self.cursor
+        self.bytes().len() - self.cursor.get()
     }
 
     #[inline(always)]
-    pub(crate) fn is_empty(&self) -> bool {
-        debug_assert!(self.cursor <= self.bytes.len());
-        self.cursor >= self.bytes.len()
-    }
-
-    #[inline(always)]
-    pub(crate) fn set_remaining(&mut self, n: usize) {
+    pub(crate) fn set_remaining(&self, n: usize) {
         // We can use `bytes.advance()` here, but it's slower.
-        self.cursor = self.bytes.len() - n;
+        self.cursor.set(self.bytes().len() - n);
     }
 
     #[cfg(any(test, feature = "lz4"))]
@@ -35,33 +30,47 @@ impl BytesExt {
         debug_assert!(n <= self.remaining());
 
         // We can use `bytes.advance()` here, but it's slower.
-        self.cursor += n;
+        self.cursor.set(self.cursor.get() + n);
     }
 
     #[inline(always)]
     pub(crate) fn extend(&mut self, chunk: Bytes) {
-        if self.is_empty() {
-            // Most of the time, we read the next chunk after consuming the previous one.
-            self.bytes = chunk;
-            self.cursor = 0;
-        } else {
-            // Some bytes are left in the buffer, we need to merge them with the next chunk.
-            self.extend_slow(chunk);
-        }
+        *self.bytes.get_mut() = merge_bytes(self.slice(), chunk);
+        self.cursor.set(0);
     }
 
-    #[cold]
-    #[inline(never)]
-    fn extend_slow(&mut self, chunk: Bytes) {
-        let total = self.remaining() + chunk.len();
-        let mut new_bytes = BytesMut::with_capacity(total);
-        let capacity = new_bytes.capacity();
-        new_bytes.extend_from_slice(self.slice());
-        new_bytes.extend_from_slice(&chunk);
-        debug_assert_eq!(new_bytes.capacity(), capacity);
-        self.bytes = new_bytes.freeze();
-        self.cursor = 0;
+    #[inline(always)]
+    pub(crate) unsafe fn extend_by_ref(&self, chunk: Bytes) {
+        let bytes = &mut *self.bytes.get();
+        *bytes = merge_bytes(self.slice(), chunk);
+        self.cursor.set(0);
     }
+
+    fn bytes(&self) -> &Bytes {
+        unsafe { &*self.bytes.get() }
+    }
+}
+
+fn merge_bytes(lhs: &[u8], rhs: Bytes) -> Bytes {
+    if lhs.is_empty() {
+        // Most of the time, we read the next chunk after consuming the previous one.
+        rhs
+    } else {
+        // Some bytes are left in the buffer, we need to merge them with the next chunk.
+        merge_bytes_slow(lhs, rhs)
+    }
+}
+
+#[cold]
+#[inline(never)]
+fn merge_bytes_slow(lhs: &[u8], rhs: Bytes) -> Bytes {
+    let new_len = lhs.len() + rhs.len();
+    let mut new_bytes = BytesMut::with_capacity(new_len);
+    let capacity = new_bytes.capacity();
+    new_bytes.extend_from_slice(lhs);
+    new_bytes.extend_from_slice(&rhs);
+    debug_assert_eq!(new_bytes.capacity(), capacity);
+    new_bytes.freeze()
 }
 
 #[test]

--- a/src/cursors/mod.rs
+++ b/src/cursors/mod.rs
@@ -4,10 +4,3 @@ pub use self::{bytes::BytesCursor, row::RowCursor};
 mod bytes;
 mod raw;
 mod row;
-
-// XXX: it was a workaround for https://github.com/rust-lang/rust/issues/51132,
-//      but introduced #24 and must be fixed.
-fn workaround_51132<'a, T: ?Sized>(ptr: &T) -> &'a T {
-    // SAFETY: actually, it leads to unsoundness, see #24
-    unsafe { &*(ptr as *const T) }
-}

--- a/src/cursors/row.rs
+++ b/src/cursors/row.rs
@@ -97,7 +97,7 @@ impl<T> RowCursor<T> {
         loop {
             if self.bytes.remaining() > 0 {
                 let mut slice = self.bytes.slice();
-                let result = rowbinary::deserialize_row_from::<T::Value<'_>>(
+                let result = rowbinary::deserialize_row::<T::Value<'_>>(
                     &mut slice,
                     self.row_metadata.as_ref(),
                 );
@@ -117,7 +117,7 @@ impl<T> RowCursor<T> {
                     // SAFETY: we actually don't have active immutable references at this point.
                     //
                     // The borrow checker prior to polonius thinks we still have ones.
-                    // This is pretty common restriction that can be fixed by using
+                    // This is a pretty common restriction that can be fixed by using
                     // the polonius-the-crab crate, which cannot be used in async code.
                     //
                     // See https://github.com/rust-lang/rust/issues/51132

--- a/src/cursors/row.rs
+++ b/src/cursors/row.rs
@@ -4,7 +4,7 @@ use crate::{
     cursors::RawCursor,
     error::{Error, Result},
     response::Response,
-    rowbinary, ReadRow,
+    rowbinary, RowRead,
 };
 use clickhouse_types::error::TypesError;
 use clickhouse_types::parse_rbwnat_columns_header;
@@ -37,7 +37,7 @@ impl<T> RowCursor<T> {
     #[inline(never)]
     async fn read_columns(&mut self) -> Result<()>
     where
-        T: ReadRow,
+        T: RowRead,
     {
         loop {
             if self.bytes.remaining() > 0 {
@@ -85,7 +85,7 @@ impl<T> RowCursor<T> {
     /// This method is cancellation safe.
     pub async fn next(&mut self) -> Result<Option<T::Value<'_>>>
     where
-        T: ReadRow,
+        T: RowRead,
     {
         if self.validation && self.row_metadata.is_none() {
             self.read_columns().await?;

--- a/src/cursors/row.rs
+++ b/src/cursors/row.rs
@@ -4,11 +4,10 @@ use crate::{
     cursors::RawCursor,
     error::{Error, Result},
     response::Response,
-    rowbinary, Row,
+    rowbinary, ReadRow,
 };
 use clickhouse_types::error::TypesError;
 use clickhouse_types::parse_rbwnat_columns_header;
-use serde::Deserialize;
 use std::marker::PhantomData;
 
 /// A cursor that emits rows deserialized as structures from RowBinary.
@@ -38,7 +37,7 @@ impl<T> RowCursor<T> {
     #[inline(never)]
     async fn read_columns(&mut self) -> Result<()>
     where
-        T: Row,
+        T: ReadRow,
     {
         loop {
             if self.bytes.remaining() > 0 {
@@ -84,10 +83,9 @@ impl<T> RowCursor<T> {
     /// # Cancel safety
     ///
     /// This method is cancellation safe.
-    pub async fn next<'cursor>(&'cursor mut self) -> Result<Option<T::Value<'cursor>>>
+    pub async fn next(&mut self) -> Result<Option<T::Value<'_>>>
     where
-        T: Row,
-        T::Value<'cursor>: Deserialize<'cursor>,
+        T: ReadRow,
     {
         if self.validation && self.row_metadata.is_none() {
             self.read_columns().await?;

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -14,7 +14,7 @@ use crate::{
     error::{Error, Result},
     request_body::{ChunkSender, RequestBody},
     response::Response,
-    row::{self, Row, WriteRow},
+    row::{self, Row, RowWrite},
     rowbinary, Client, Compression,
 };
 
@@ -210,7 +210,7 @@ impl<T> Insert<T> {
         row: &T::Value<'_>,
     ) -> impl Future<Output = Result<()>> + 'a + Send
     where
-        T: WriteRow,
+        T: RowWrite,
     {
         let result = self.do_write(row);
 
@@ -226,7 +226,7 @@ impl<T> Insert<T> {
     #[inline(always)]
     pub(crate) fn do_write(&mut self, row: &T::Value<'_>) -> Result<usize>
     where
-        T: WriteRow,
+        T: RowWrite,
     {
         match self.state {
             InsertState::NotStarted { .. } => self.init_request(),

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -5,7 +5,7 @@ use tokio::time::Duration;
 use crate::{
     error::Result,
     insert::Insert,
-    row::{Row, WriteRow},
+    row::{Row, RowWrite},
     ticks::Ticks,
     Client,
 };
@@ -222,7 +222,7 @@ where
     #[inline]
     pub fn write(&mut self, row: &T::Value<'_>) -> Result<()>
     where
-        T: WriteRow,
+        T: RowWrite,
     {
         if self.insert.is_none() {
             self.init_insert()?;

--- a/src/inserter.rs
+++ b/src/inserter.rs
@@ -1,9 +1,14 @@
 use std::mem;
 
-use serde::Serialize;
 use tokio::time::Duration;
 
-use crate::{error::Result, insert::Insert, row::Row, ticks::Ticks, Client};
+use crate::{
+    error::Result,
+    insert::Insert,
+    row::{Row, WriteRow},
+    ticks::Ticks,
+    Client,
+};
 
 /// Performs multiple consecutive `INSERT`s.
 ///
@@ -215,9 +220,9 @@ where
     /// # Panics
     /// If called after the previous call that returned an error.
     #[inline]
-    pub fn write(&mut self, row: &T) -> Result<()>
+    pub fn write(&mut self, row: &T::Value<'_>) -> Result<()>
     where
-        T: Serialize,
+        T: WriteRow,
     {
         if self.insert.is_none() {
             self.init_insert()?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,10 @@
 #[macro_use]
 extern crate static_assertions;
 
-pub use self::{compression::Compression, row::Row, row::RowKind};
+pub use self::{
+    compression::Compression,
+    row::{ReadRow, Row, RowKind, RowOwned},
+};
 use self::{error::Result, http_client::HttpClient};
 pub use clickhouse_derive::Row;
 use std::{collections::HashMap, fmt::Display, sync::Arc};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate static_assertions;
 
 pub use self::{
     compression::Compression,
-    row::{ReadRow, Row, RowOwned, WriteRow},
+    row::{Row, RowOwned, RowRead, RowWrite},
 };
 use self::{error::Result, http_client::HttpClient};
 pub use clickhouse_derive::Row;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate static_assertions;
 
 pub use self::{
     compression::Compression,
-    row::{ReadRow, Row, RowOwned},
+    row::{ReadRow, Row, RowOwned, WriteRow},
 };
 use self::{error::Result, http_client::HttpClient};
 pub use clickhouse_derive::Row;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ extern crate static_assertions;
 
 pub use self::{
     compression::Compression,
-    row::{ReadRow, Row, RowKind, RowOwned},
+    row::{ReadRow, Row, RowOwned},
 };
 use self::{error::Result, http_client::HttpClient};
 pub use clickhouse_derive::Row;
@@ -381,6 +381,8 @@ impl Client {
 /// Do not use it in your code directly, it doesn't follow semver.
 #[doc(hidden)]
 pub mod _priv {
+    pub use crate::row::RowKind;
+
     #[cfg(feature = "lz4")]
     pub fn lz4_compress(uncompressed: &[u8]) -> super::Result<bytes::Bytes> {
         crate::compression::lz4::compress(uncompressed)

--- a/src/query.rs
+++ b/src/query.rs
@@ -8,7 +8,7 @@ use crate::{
     headers::with_request_headers,
     request_body::RequestBody,
     response::Response,
-    row::{ReadRow, Row, RowOwned},
+    row::{Row, RowOwned, RowRead},
     sql::{ser, Bind, SqlBuilder},
     Client,
 };
@@ -102,7 +102,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_one<T>(self) -> Result<T>
     where
-        T: RowOwned + ReadRow,
+        T: RowOwned + RowRead,
     {
         match self.fetch::<T>()?.next().await {
             Ok(Some(row)) => Ok(row),
@@ -116,7 +116,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_optional<T>(self) -> Result<Option<T>>
     where
-        T: RowOwned + ReadRow,
+        T: RowOwned + RowRead,
     {
         self.fetch::<T>()?.next().await
     }
@@ -127,7 +127,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_all<T>(self) -> Result<Vec<T>>
     where
-        T: RowOwned + ReadRow,
+        T: RowOwned + RowRead,
     {
         let mut result = Vec::new();
         let mut cursor = self.fetch::<T>()?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,5 @@
 use hyper::{header::CONTENT_LENGTH, Method, Request};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::Serialize;
 use std::fmt::Display;
 use url::Url;
 
@@ -8,7 +8,7 @@ use crate::{
     headers::with_request_headers,
     request_body::RequestBody,
     response::Response,
-    row::{Row, RowOwned},
+    row::{ReadRow, Row, RowOwned},
     sql::{ser, Bind, SqlBuilder},
     Client,
 };
@@ -102,7 +102,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_one<T>(self) -> Result<T>
     where
-        T: RowOwned + DeserializeOwned,
+        T: RowOwned + ReadRow,
     {
         match self.fetch::<T>()?.next().await {
             Ok(Some(row)) => Ok(row),
@@ -116,7 +116,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_optional<T>(self) -> Result<Option<T>>
     where
-        T: RowOwned + DeserializeOwned,
+        T: RowOwned + ReadRow,
     {
         self.fetch::<T>()?.next().await
     }
@@ -127,7 +127,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_all<T>(self) -> Result<Vec<T>>
     where
-        T: RowOwned + DeserializeOwned,
+        T: RowOwned + ReadRow,
     {
         let mut result = Vec::new();
         let mut cursor = self.fetch::<T>()?;

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,5 +1,5 @@
 use hyper::{header::CONTENT_LENGTH, Method, Request};
-use serde::{Deserialize, Serialize};
+use serde::{de::DeserializeOwned, Serialize};
 use std::fmt::Display;
 use url::Url;
 
@@ -8,7 +8,7 @@ use crate::{
     headers::with_request_headers,
     request_body::RequestBody,
     response::Response,
-    row::Row,
+    row::{Row, RowOwned},
     sql::{ser, Bind, SqlBuilder},
     Client,
 };
@@ -102,9 +102,9 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_one<T>(self) -> Result<T>
     where
-        T: Row + for<'b> Deserialize<'b>,
+        T: RowOwned + DeserializeOwned,
     {
-        match self.fetch()?.next().await {
+        match self.fetch::<T>()?.next().await {
             Ok(Some(row)) => Ok(row),
             Ok(None) => Err(Error::RowNotFound),
             Err(err) => Err(err),
@@ -116,9 +116,9 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_optional<T>(self) -> Result<Option<T>>
     where
-        T: Row + for<'b> Deserialize<'b>,
+        T: RowOwned + DeserializeOwned,
     {
-        self.fetch()?.next().await
+        self.fetch::<T>()?.next().await
     }
 
     /// Executes the query and returns all the generated results,
@@ -127,7 +127,7 @@ impl Query {
     /// Note that `T` must be owned.
     pub async fn fetch_all<T>(self) -> Result<Vec<T>>
     where
-        T: Row + for<'b> Deserialize<'b>,
+        T: RowOwned + DeserializeOwned,
     {
         let mut result = Vec::new();
         let mut cursor = self.fetch::<T>()?;

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,6 +1,7 @@
 use crate::sql;
 use serde::Deserialize;
 
+#[doc(hidden)]
 #[derive(Debug, Clone, PartialEq)]
 pub enum RowKind {
     Primitive,

--- a/src/row.rs
+++ b/src/row.rs
@@ -9,21 +9,40 @@ pub enum RowKind {
     Vec,
 }
 
+/// Represents a row that can be used in queries.
+///
+/// Implemented for:
+/// * All `#[derive(Row)]` items
+/// * `(P1, P2, ...)` where P* is a primitive type or string
+///
+/// Do not implement this trait directly, use `#[derive(Row)]` instead.
+///
+/// In order to write a generic code over rows, see `ReadRow`.
 pub trait Row {
+    // NOTE: all properties are unstable and, hence, not following semver.
+
+    #[doc(hidden)]
     const NAME: &'static str;
-    const COLUMN_NAMES: &'static [&'static str];
-    const COLUMN_COUNT: usize;
-    const KIND: RowKind;
-
-    type Value<'a>: Row;
-
-    // TODO: count
     // TODO: different list for SELECT/INSERT (de/ser)
+    #[doc(hidden)]
+    const COLUMN_NAMES: &'static [&'static str];
+    #[doc(hidden)]
+    const COLUMN_COUNT: usize;
+    #[doc(hidden)]
+    const KIND: RowKind;
+    #[doc(hidden)]
+    type Value<'a>: Row;
 }
 
+/// Represents a row that can be read from the database.
+///
+/// This trait is implemented automatically and useful for writing generic code.
 pub trait ReadRow: for<'a> Row<Value<'a>: Deserialize<'a>> {}
 impl<R> ReadRow for R where R: for<'a> Row<Value<'a>: Deserialize<'a>> {}
 
+/// Represents a row not holding any references.
+///
+/// This trait is implemented automatically and useful for writing generic code.
 pub trait RowOwned: 'static + for<'a> Row<Value<'a> = Self> {}
 impl<R> RowOwned for R where R: 'static + for<'a> Row<Value<'a> = R> {}
 

--- a/src/row.rs
+++ b/src/row.rs
@@ -1,5 +1,5 @@
 use crate::sql;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 #[doc(hidden)]
 #[derive(Debug, Clone, PartialEq)]
@@ -40,6 +40,9 @@ pub trait Row {
 /// This trait is implemented automatically and useful for writing generic code.
 pub trait ReadRow: for<'a> Row<Value<'a>: Deserialize<'a>> {}
 impl<R> ReadRow for R where R: for<'a> Row<Value<'a>: Deserialize<'a>> {}
+
+pub trait WriteRow: for<'a> Row<Value<'a>: Serialize> {}
+impl<R> WriteRow for R where R: for<'a> Row<Value<'a>: Serialize> {}
 
 /// Represents a row not holding any references.
 ///

--- a/src/row_metadata.rs
+++ b/src/row_metadata.rs
@@ -25,6 +25,9 @@ pub(crate) enum AccessType {
     WithMapAccess(Vec<usize>),
 }
 
+/// Contains a vector of [`Column`] objects parsed from the beginning
+/// of `RowBinaryWithNamesAndTypes` data stream.
+///
 /// [`RowMetadata`] should be owned outside the (de)serializer,
 /// as it is calculated only once per struct. It does not have lifetimes,
 /// so it does not introduce a breaking change to [`crate::cursors::RowCursor`].

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -14,6 +14,17 @@ use serde::{
 use std::marker::PhantomData;
 use std::{convert::TryFrom, str};
 
+// TODO: doc + remove below?
+pub(crate) fn deserialize_row_from<'data, 'cursor, T: Deserialize<'data> + Row>(
+    input: &mut &'data [u8],
+    metadata: Option<&'cursor RowMetadata>,
+) -> Result<T> {
+    match metadata {
+        Some(metadata) => deserialize_row_with_validation(input, metadata),
+        None => deserialize_row(input),
+    }
+}
+
 /// Deserializes a value from `input` with a row encoded in `RowBinary`,
 /// i.e. only when [`crate::Row`] validation is disabled in the client.
 ///

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -1,8 +1,7 @@
 use crate::error::{Error, Result};
 use crate::row_metadata::RowMetadata;
 use crate::rowbinary::utils::{ensure_size, get_unsigned_leb128};
-use crate::rowbinary::validation::SerdeType;
-use crate::rowbinary::validation::{DataTypeValidator, SchemaValidator};
+use crate::rowbinary::validation::{DataTypeValidator, SchemaValidator, SerdeType};
 use crate::Row;
 use bytes::Buf;
 use core::mem::size_of;

--- a/src/rowbinary/mod.rs
+++ b/src/rowbinary/mod.rs
@@ -1,5 +1,5 @@
-pub(crate) use de::deserialize_row;
 pub(crate) use de::deserialize_row_with_validation;
+pub(crate) use de::{deserialize_row, deserialize_row_from};
 pub(crate) use ser::serialize_into;
 
 pub(crate) mod validation;

--- a/src/rowbinary/mod.rs
+++ b/src/rowbinary/mod.rs
@@ -1,5 +1,4 @@
-pub(crate) use de::deserialize_row_with_validation;
-pub(crate) use de::{deserialize_row, deserialize_row_from};
+pub(crate) use de::deserialize_row;
 pub(crate) use ser::serialize_into;
 
 pub(crate) mod validation;

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -62,7 +62,7 @@ impl Row for Sample<'_> {
         "boolean",
     ];
     const COLUMN_COUNT: usize = 19;
-    const KIND: crate::RowKind = crate::RowKind::Struct;
+    const KIND: crate::row::RowKind = crate::row::RowKind::Struct;
 
     type Value<'a> = Sample<'a>;
 }

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -153,10 +153,10 @@ fn it_deserializes() {
         let (mut left, mut right) = input.split_at(i);
 
         // It shouldn't panic.
-        let _: Result<Sample<'_>, _> = super::deserialize_row(&mut left);
-        let _: Result<Sample<'_>, _> = super::deserialize_row(&mut right);
+        let _: Result<Sample<'_>, _> = super::deserialize_row(&mut left, None);
+        let _: Result<Sample<'_>, _> = super::deserialize_row(&mut right, None);
 
-        let actual: Sample<'_> = super::deserialize_row(&mut input.as_slice()).unwrap();
+        let actual: Sample<'_> = super::deserialize_row(&mut input.as_slice(), None).unwrap();
         assert_eq!(actual, sample());
     }
 }

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -63,6 +63,8 @@ impl Row for Sample<'_> {
     ];
     const COLUMN_COUNT: usize = 19;
     const KIND: crate::RowKind = crate::RowKind::Struct;
+
+    type Value<'a> = Sample<'a>;
 }
 
 fn sample() -> Sample<'static> {

--- a/src/rowbinary/validation.rs
+++ b/src/rowbinary/validation.rs
@@ -1,5 +1,4 @@
-use crate::row_metadata::RowMetadata;
-use crate::{Row, RowKind};
+use crate::{row::RowKind, row_metadata::RowMetadata, Row};
 use clickhouse_types::data_types::{Column, DataTypeNode, DecimalType, EnumType};
 use std::collections::HashMap;
 use std::fmt::Display;

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -4,10 +4,10 @@ use bytes::Bytes;
 use futures::channel::oneshot;
 use hyper::{Request, Response, StatusCode};
 use sealed::sealed;
-use serde::{Deserialize, Serialize};
+use serde::Serialize;
 
 use super::{Handler, HandlerFn};
-use crate::{rowbinary, Row};
+use crate::{rowbinary, ReadRow, RowOwned};
 
 const BUFFER_INITIAL_CAPACITY: usize = 1024;
 
@@ -82,7 +82,7 @@ pub struct RecordControl<T> {
 
 impl<T> RecordControl<T>
 where
-    T: for<'a> Deserialize<'a> + Row,
+    T: RowOwned + ReadRow,
 {
     pub async fn collect<C>(self) -> C
     where

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -7,7 +7,7 @@ use sealed::sealed;
 use serde::Serialize;
 
 use super::{Handler, HandlerFn};
-use crate::{rowbinary, ReadRow, RowOwned};
+use crate::{rowbinary, RowOwned, RowRead};
 
 const BUFFER_INITIAL_CAPACITY: usize = 1024;
 
@@ -82,7 +82,7 @@ pub struct RecordControl<T> {
 
 impl<T> RecordControl<T>
 where
-    T: RowOwned + ReadRow,
+    T: RowOwned + RowRead,
 {
     pub async fn collect<C>(self) -> C
     where

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -93,7 +93,7 @@ where
         let mut result = C::default();
 
         while !slice.is_empty() {
-            let res = rowbinary::deserialize_row(slice);
+            let res = rowbinary::deserialize_row(slice, None);
             let row: T = res.expect("failed to deserialize");
             result.extend(std::iter::once(row));
         }

--- a/tests/it/chrono.rs
+++ b/tests/it/chrono.rs
@@ -88,7 +88,7 @@ async fn datetime() {
         dt64ns_opt: Some(dt_ns),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 
@@ -146,7 +146,7 @@ async fn date() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
 
     let dates = generate_dates(1970..2149, 100);
     for &date in &dates {
@@ -199,7 +199,7 @@ async fn date32() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
 
     let dates = generate_dates(1925..2283, 100); // TODO: 1900..=2299 for newer versions.
     for &date in &dates {

--- a/tests/it/compression.rs
+++ b/tests/it/compression.rs
@@ -5,7 +5,7 @@ use crate::{create_simple_table, SimpleRow};
 async fn check(client: Client) {
     create_simple_table(&client, "test").await;
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<SimpleRow>("test").unwrap();
     for i in 0..200_000 {
         insert.write(&SimpleRow::new(i, "foo")).await.unwrap();
     }

--- a/tests/it/cursor_error.rs
+++ b/tests/it/cursor_error.rs
@@ -67,7 +67,7 @@ async fn deferred_lz4() {
 
     // Due to compression we need more complex test here: write a lot of big parts.
     for i in 0..part_count {
-        let mut insert = client.insert("test").unwrap();
+        let mut insert = client.insert::<Row>("test").unwrap();
 
         for j in 0..part_size {
             let row = Row {

--- a/tests/it/cursor_stats.rs
+++ b/tests/it/cursor_stats.rs
@@ -5,7 +5,7 @@ use crate::{create_simple_table, SimpleRow};
 async fn check(client: Client, expected_ratio: f64) {
     create_simple_table(&client, "test").await;
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<SimpleRow>("test").unwrap();
     for i in 0..1_000 {
         insert.write(&SimpleRow::new(i, "foobar")).await.unwrap();
     }

--- a/tests/it/inserter.rs
+++ b/tests/it/inserter.rs
@@ -34,7 +34,7 @@ async fn force_commit() {
     let client = prepare_database!();
     create_table(&client).await;
 
-    let mut inserter = client.inserter("test").unwrap();
+    let mut inserter = client.inserter::<MyRow>("test").unwrap();
     let rows = 100;
 
     for i in 1..=rows {
@@ -63,7 +63,7 @@ async fn limited_by_rows() {
     let client = prepare_database!();
     create_table(&client).await;
 
-    let mut inserter = client.inserter("test").unwrap().with_max_rows(10);
+    let mut inserter = client.inserter::<MyRow>("test").unwrap().with_max_rows(10);
     let rows = 100;
 
     for i in (2..=rows).step_by(2) {
@@ -105,7 +105,10 @@ async fn limited_by_bytes() {
     let client = prepare_database!();
     create_table(&client).await;
 
-    let mut inserter = client.inserter("test").unwrap().with_max_bytes(100);
+    let mut inserter = client
+        .inserter::<MyRow>("test")
+        .unwrap()
+        .with_max_bytes(100);
     let rows = 100;
 
     let row = MyRow::new("x".repeat(9));
@@ -149,7 +152,10 @@ async fn limited_by_time() {
     create_table(&client).await;
 
     let period = Duration::from_secs(1);
-    let mut inserter = client.inserter("test").unwrap().with_period(Some(period));
+    let mut inserter = client
+        .inserter::<MyRow>("test")
+        .unwrap()
+        .with_period(Some(period));
     let rows = 100;
 
     for i in 1..=rows {
@@ -200,7 +206,7 @@ async fn keeps_client_options() {
     let row = SimpleRow::new(42, "foo");
 
     let mut inserter = client
-        .inserter(table_name)
+        .inserter::<SimpleRow>(table_name)
         .unwrap()
         .with_option("async_insert", "1")
         .with_option("query_id", &query_id);
@@ -253,7 +259,7 @@ async fn overrides_client_options() {
     let row = SimpleRow::new(42, "foo");
 
     let mut inserter = client
-        .inserter(table_name)
+        .inserter::<SimpleRow>(table_name)
         .unwrap()
         .with_option("async_insert", override_value)
         .with_option("query_id", &query_id);

--- a/tests/it/int128.rs
+++ b/tests/it/int128.rs
@@ -44,7 +44,7 @@ async fn u128() {
         },
     ];
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     for row in &original_rows {
         insert.write(row).await.unwrap();
     }
@@ -103,7 +103,7 @@ async fn i128() {
         },
     ];
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     for row in &original_rows {
         insert.write(row).await.unwrap();
     }

--- a/tests/it/ip.rs
+++ b/tests/it/ip.rs
@@ -40,7 +40,7 @@ async fn smoke() {
         ipv6_opt: Some(Ipv6Addr::new(0x2001, 0xdb8, 0, 0, 0, 0xafc8, 0x10, 0x1)),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -1,4 +1,4 @@
-//! ## Integration tests
+//! # Integration tests
 //!
 //! - The `wait_end_of_query` setting that is used for all DDLs forces HTTP response buffering.
 //!   We will get the response only when the DDL is executed on every cluster node.

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,8 +24,8 @@
 //!   from the Cloud instance based on its creation time. See
 //!   [`_priv::make_db_name`].
 
-use clickhouse::{sql::Identifier, Client, Row};
-use serde::{Deserialize, Serialize};
+use clickhouse::{sql::Identifier, Client, Row, RowOwned};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
 
 macro_rules! assert_panic_on_fetch_with_client {
     ($client:ident, $msg_parts:expr, $query:expr) => {
@@ -138,7 +138,7 @@ pub(crate) async fn create_simple_table(client: &Client, table_name: &str) {
 
 pub(crate) async fn fetch_rows<T>(client: &Client, table_name: &str) -> Vec<T>
 where
-    T: Row + for<'b> Deserialize<'b>,
+    T: RowOwned + DeserializeOwned,
 {
     client
         .query("SELECT ?fields FROM ?")

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -25,7 +25,7 @@
 //!   the "cloud" environment, it appends the current timestamp to allow
 //!   clean up outdated databases based on its creation time.
 
-use clickhouse::{sql::Identifier, Client, ReadRow, Row, RowOwned};
+use clickhouse::{sql::Identifier, Client, Row, RowOwned, RowRead};
 use serde::{Deserialize, Serialize};
 use std::sync::LazyLock;
 
@@ -138,7 +138,7 @@ pub(crate) async fn create_simple_table(client: &Client, table_name: &str) {
 
 pub(crate) async fn fetch_rows<T>(client: &Client, table_name: &str) -> Vec<T>
 where
-    T: RowOwned + ReadRow,
+    T: RowOwned + RowRead,
 {
     client
         .query("SELECT ?fields FROM ?")

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -24,8 +24,8 @@
 //!   from the Cloud instance based on its creation time. See
 //!   [`_priv::make_db_name`].
 
-use clickhouse::{sql::Identifier, Client, Row, RowOwned};
-use serde::{de::DeserializeOwned, Deserialize, Serialize};
+use clickhouse::{sql::Identifier, Client, ReadRow, Row, RowOwned};
+use serde::{Deserialize, Serialize};
 
 macro_rules! assert_panic_on_fetch_with_client {
     ($client:ident, $msg_parts:expr, $query:expr) => {
@@ -138,7 +138,7 @@ pub(crate) async fn create_simple_table(client: &Client, table_name: &str) {
 
 pub(crate) async fn fetch_rows<T>(client: &Client, table_name: &str) -> Vec<T>
 where
-    T: RowOwned + DeserializeOwned,
+    T: RowOwned + ReadRow,
 {
     client
         .query("SELECT ?fields FROM ?")

--- a/tests/it/nested.rs
+++ b/tests/it/nested.rs
@@ -38,7 +38,7 @@ async fn smoke() {
         items_count: vec![1, 5],
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -26,7 +26,7 @@ async fn smoke() {
         .unwrap();
 
     // Write to the table.
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow<'_>>("test").unwrap();
     for i in 0..1000 {
         insert.write(&MyRow { no: i, name: "foo" }).await.unwrap();
     }
@@ -73,7 +73,7 @@ async fn fetch_one_and_optional() {
         n: String,
     }
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<Row>("test").unwrap();
     insert.write(&Row { n: "foo".into() }).await.unwrap();
     insert.write(&Row { n: "bar".into() }).await.unwrap();
     insert.end().await.unwrap();
@@ -165,7 +165,7 @@ async fn big_borrowed_str() {
 
     let long_string = "A".repeat(10000);
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow<'_>>("test").unwrap();
     insert
         .write(&MyRow {
             no: 0,
@@ -201,7 +201,7 @@ async fn all_floats() {
         f: f64,
     }
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<Row>("test").unwrap();
     insert.write(&Row { no: 0, f: 42.5 }).await.unwrap();
     insert.write(&Row { no: 1, f: 43.5 }).await.unwrap();
     insert.end().await.unwrap();

--- a/tests/it/rbwnat.rs
+++ b/tests/it/rbwnat.rs
@@ -349,8 +349,6 @@ async fn basic_types() {
     );
 }
 
-// FIXME: somehow this test breaks `cargo test`, but works from RustRover
-#[ignore]
 #[tokio::test]
 async fn borrowed_data() {
     #[derive(Debug, Row, Serialize, Deserialize, PartialEq)]
@@ -403,46 +401,45 @@ async fn borrowed_data() {
         .fetch::<Data<'_>>()
         .unwrap();
 
-    let mut result = Vec::new();
-    while let Some(row) = cursor.next().await.unwrap() {
-        result.push(row);
-    }
+    assert_eq!(
+        cursor.next().await.unwrap().unwrap(),
+        Data {
+            str: "a",
+            array: vec!["b", "c"],
+            tuple: ("d", "e"),
+            str_opt: None,
+            vec_map_str: vec![("key1", "value1"), ("key2", "value2")],
+            vec_map_f32: vec![("key3", 100.0), ("key4", 200.0)],
+            vec_map_nested: vec![("n1", vec![("key1", "value1"), ("key2", "value2")])],
+            hash_map_str: HashMap::from([("key1", "value1"), ("key2", "value2")]),
+            hash_map_f32: HashMap::from([("key3", 100.0), ("key4", 200.0)]),
+            hash_map_nested: HashMap::from([(
+                "n1",
+                HashMap::from([("key1", "value1"), ("key2", "value2")]),
+            )]),
+        }
+    );
 
     assert_eq!(
-        result,
-        vec![
-            Data {
-                str: "a",
-                array: vec!["b", "c"],
-                tuple: ("d", "e"),
-                str_opt: None,
-                vec_map_str: vec![("key1", "value1"), ("key2", "value2")],
-                vec_map_f32: vec![("key3", 100.0), ("key4", 200.0)],
-                vec_map_nested: vec![("n1", vec![("key1", "value1"), ("key2", "value2")])],
-                hash_map_str: HashMap::from([("key1", "value1"), ("key2", "value2"),]),
-                hash_map_f32: HashMap::from([("key3", 100.0), ("key4", 200.0),]),
-                hash_map_nested: HashMap::from([(
-                    "n1",
-                    HashMap::from([("key1", "value1"), ("key2", "value2"),]),
-                )]),
-            },
-            Data {
-                str: "f",
-                array: vec!["g", "h"],
-                tuple: ("i", "j"),
-                str_opt: Some("k"),
-                vec_map_str: vec![("key4", "value4"), ("key5", "value5")],
-                vec_map_f32: vec![("key6", 300.0), ("key7", 400.0)],
-                vec_map_nested: vec![("n2", vec![("key4", "value4"), ("key5", "value5")])],
-                hash_map_str: HashMap::from([("key4", "value4"), ("key5", "value5"),]),
-                hash_map_f32: HashMap::from([("key6", 300.0), ("key7", 400.0),]),
-                hash_map_nested: HashMap::from([(
-                    "n2",
-                    HashMap::from([("key4", "value4"), ("key5", "value5"),]),
-                )]),
-            },
-        ]
+        cursor.next().await.unwrap().unwrap(),
+        Data {
+            str: "f",
+            array: vec!["g", "h"],
+            tuple: ("i", "j"),
+            str_opt: Some("k"),
+            vec_map_str: vec![("key4", "value4"), ("key5", "value5")],
+            vec_map_f32: vec![("key6", 300.0), ("key7", 400.0)],
+            vec_map_nested: vec![("n2", vec![("key4", "value4"), ("key5", "value5")])],
+            hash_map_str: HashMap::from([("key4", "value4"), ("key5", "value5")]),
+            hash_map_f32: HashMap::from([("key6", 300.0), ("key7", 400.0)]),
+            hash_map_nested: HashMap::from([(
+                "n2",
+                HashMap::from([("key4", "value4"), ("key5", "value5")]),
+            )]),
+        },
     );
+
+    assert!(cursor.next().await.unwrap().is_none());
 }
 
 #[tokio::test]

--- a/tests/it/rbwnat.rs
+++ b/tests/it/rbwnat.rs
@@ -755,7 +755,7 @@ async fn enums() {
         },
     ];
 
-    let mut insert = client.insert(table_name).unwrap();
+    let mut insert = client.insert::<Data>(table_name).unwrap();
     for row in &expected {
         insert.write(row).await.unwrap()
     }
@@ -1346,7 +1346,7 @@ async fn issue_109_1() {
         .fetch_all::<Data>()
         .await
         .unwrap();
-    let mut insert = client.insert("issue_109").unwrap();
+    let mut insert = client.insert::<Data>("issue_109").unwrap();
     for (id, elem) in data.iter().enumerate() {
         let elem = Data {
             en_id: format!("ABC-{}", id),

--- a/tests/it/time.rs
+++ b/tests/it/time.rs
@@ -80,7 +80,7 @@ async fn datetime() {
         dt64ns_opt: Some(datetime!(2022-11-13 15:27:42.123456789 UTC)),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 
@@ -138,7 +138,7 @@ async fn date() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
 
     let dates = generate_dates(1970..2149, 100);
     for &date in &dates {
@@ -191,7 +191,7 @@ async fn date32() {
         .await
         .unwrap();
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
 
     let dates = generate_dates(1925..2283, 100); // TODO: 1900..=2299 for newer versions.
     for &date in &dates {

--- a/tests/it/user_agent.rs
+++ b/tests/it/user_agent.rs
@@ -40,7 +40,7 @@ async fn assert_queries_user_agents(client: &Client, table_name: &str, expected_
 
     create_simple_table(client, table_name).await;
 
-    let mut insert = client.insert(table_name).unwrap();
+    let mut insert = client.insert::<SimpleRow>(table_name).unwrap();
     insert.write(&row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/uuid.rs
+++ b/tests/it/uuid.rs
@@ -38,7 +38,7 @@ async fn smoke() {
         uuid_opt: Some(uuid),
     };
 
-    let mut insert = client.insert("test").unwrap();
+    let mut insert = client.insert::<MyRow>("test").unwrap();
     insert.write(&original_row).await.unwrap();
     insert.end().await.unwrap();
 

--- a/tests/it/variant.rs
+++ b/tests/it/variant.rs
@@ -90,7 +90,7 @@ async fn variant_data_type() {
     let rows = vars.map(|var| MyRow { var });
 
     // Write to the table.
-    let mut insert = client.insert("test_var").unwrap();
+    let mut insert = client.insert::<MyRow>("test_var").unwrap();
     for row in &rows {
         insert.write(row).await.unwrap();
     }

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -1,0 +1,13 @@
+//! # UI failure tests
+//!
+//! These tests are designed to ensure that the `#[derive(Row)]` macro
+//! produces expected errors when used incorrectly. Test cases must be
+//! added to the `tests/ui/` directory (use existing ones as an example).
+//!
+//! Run with `TRYBUILD=overwrite` to update snapshots (*.stderr files).
+
+#[test]
+fn ui() {
+    let t = trybuild::TestCases::new();
+    t.compile_fail("tests/ui/*.rs");
+}

--- a/tests/ui/row_forbidden.rs
+++ b/tests/ui/row_forbidden.rs
@@ -1,0 +1,19 @@
+#[derive(clickhouse::Row)]
+enum Enum {
+    A(i32),
+    B(String),
+}
+
+#[derive(clickhouse::Row)]
+union Union {
+    a: i32,
+    b: u64,
+}
+
+#[derive(clickhouse::Row)]
+pub struct UnitStruct;
+
+#[derive(clickhouse::Row)]
+pub struct EmptyStruct {}
+
+fn main() {}

--- a/tests/ui/row_forbidden.stderr
+++ b/tests/ui/row_forbidden.stderr
@@ -1,0 +1,23 @@
+error: `Row` can only be derived for structs
+ --> tests/ui/row_forbidden.rs:2:6
+  |
+2 | enum Enum {
+  |      ^^^^
+
+error: `Row` can only be derived for structs
+ --> tests/ui/row_forbidden.rs:8:7
+  |
+8 | union Union {
+  |       ^^^^^
+
+error: `Row` cannot be derived for unit or empty structs
+  --> tests/ui/row_forbidden.rs:14:12
+   |
+14 | pub struct UnitStruct;
+   |            ^^^^^^^^^^
+
+error: `Row` cannot be derived for unit or empty structs
+  --> tests/ui/row_forbidden.rs:17:12
+   |
+17 | pub struct EmptyStruct {}
+   |            ^^^^^^^^^^^

--- a/tests/ui/row_many_lifetimes.rs
+++ b/tests/ui/row_many_lifetimes.rs
@@ -1,0 +1,7 @@
+#[derive(clickhouse::Row)]
+struct Row<'a, 'b> {
+    a: &'a str,
+    b: &'b str,
+}
+
+fn main() {}

--- a/tests/ui/row_many_lifetimes.stderr
+++ b/tests/ui/row_many_lifetimes.stderr
@@ -1,0 +1,5 @@
+error: `Row` cannot be derived for structs with multiple lifetimes
+ --> tests/ui/row_many_lifetimes.rs:2:16
+  |
+2 | struct Row<'a, 'b> {
+  |                ^^

--- a/types/src/data_types.rs
+++ b/types/src/data_types.rs
@@ -1392,7 +1392,7 @@ mod tests {
         assert_eq!(DecimalType::Decimal256.to_string(), "Decimal256");
     }
 
-    const ENUM_WITH_ESCAPING_STR: &'static str =
+    const ENUM_WITH_ESCAPING_STR: &str =
         "Enum8('f\\'' = 1, 'x =' = 2, 'b\\'\\'' = 3, '\\'c=4=' = 42, '4' = 100)";
 
     fn enum_with_escaping() -> DataTypeNode {


### PR DESCRIPTION
## Summary

This PR redesigns the usage of borrowing rows by introducing `type Value<'a>` associated type in `trait Row`.
This type points to the same row type, but allows for changing the lifetime.

<details>
  <summary>A simplified explanation for SELECTs</summary>

```rust
let cursor = client.query("...").fetch::<SomeRow<'1>>()?;
// '1 starts

// RowCursor is parametrized with SomeRow having a lifetime for the whole loop
// Actually, it can be even `'static` because this lifetime isn't used.

while let Some(row /* SomeRow<'2> */) = cursor.next().await? {
   // '2 starts
   /* code */
   // '2 ends
}

// '1 ends
```
</details>

Note that `Row::Value` is used for both select and insert queries. While the problem with unsoundness exists only for `Query::next()` API, the insert API also benefits from moving to `Row::Value`. See the `insert_from_cursor` test to see which pattern is available now. There are more complex cases where the previous insert API design doesn't fit well, but they share the same problem that is checked in that test.

These changes are unnoticeable for many use cases. However:
* The compiler cannot now infer the type of `Insert<_>` based only on `insert.write(_)` calls, so users should specify the type in `client.insert::<_>()` calls. This change likely affects many users, but can be easily corrected by specifying a type. 
* Writing generic code becomes harder. We introduce `RowRead`, `RowWrite`, and `RowOwned` helpers to simplify such cases. Please refer to the documentation for these items for examples.
* Custom implementations of `Row` are forbidden (they, in fact, should already be after moving to RBWNAT). It wasn't recommended anyway, but now it's explicitly excluded from Semver guarantees.

Besides this:
* Add `insta` snapshot tests for `#[derive(Row)]`
* Improve `#[derive(Row)]` error handling and add `trybuild` tests
* Run tests of all crates of the workspace in CI
* Add `miri` tests for unsafe code
* Run `miri` tests in CI
* Stop adding a timestamp to names of test DBs if tests are running locally (as opposed to cloud runs).

Closes #24

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
