### PR TITLE
Implement query with interpolation flags

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -9,6 +9,7 @@ If something is missing, or you found a mistake in one of these examples, please
 ### General usage
 
 - [usage.rs](usage.rs) - creating tables, executing other DDLs, inserting the data, and selecting it back. Optional cargo features: `inserter`.
+- [query_flags.rs](query_flags.rs) - Supports query interpolation flags to finely control how SQL templates are processed.
 - [mock.rs](mock.rs) - writing tests with `mock` feature. Cargo features: requires `test-util`.
 - [inserter.rs](inserter.rs) - using the client-side batching via the `inserter` feature. Cargo features: requires `inserter`.
 - [async_insert.rs](async_insert.rs) - using the server-side batching via the [asynchronous inserts](https://clickhouse.com/docs/en/optimize/asynchronous-inserts) ClickHouse feature

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -380,9 +380,38 @@ impl Client {
         inserter::Inserter::new(self, table)
     }
 
-    /// Starts a new SELECT/DDL query.
+    /// Starts a new SELECT/DDL query with default interpolation flags.
+    ///
+    /// This method uses [`query::QI::DEFAULT`] flags which enable only:
+    /// - `?fields` substitution with struct field names
+    ///
+    /// Parameter binding (`?`) is not enabled by default.
+    /// For explicit control over interpolation features, use [`Client::query_with_flags`].
     pub fn query(&self, query: &str) -> query::Query {
         query::Query::new(self, query)
+    }
+
+    /// Starts a new SELECT/DDL query with explicit interpolation flags
+    /// to specify exactly which interpolation features should be enabled.
+    ///
+    /// ## Example with both features enabled
+    /// ```rust,ignore
+    /// use clickhouse::query::QI;
+    ///
+    /// let rows = client
+    ///     .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM users WHERE age > ?")
+    ///     .bind(18)
+    ///     .fetch::<User>()
+    ///     .await?;
+    /// ```
+    ///
+    /// # Comparison with [`Client::query`]
+    ///
+    /// - [`Client::query`] uses default flags ([`query::QI::DEFAULT`]) enabling only `?fields`
+    /// - [`Client::query_with_flags`] allows explicit control over interpolation features
+    ///
+    pub fn query_with_flags<const FLAGS: u8>(&self, query: &str) -> query::Query<FLAGS> {
+        query::Query::<FLAGS>::new(self, query)
     }
 
     /// Enables or disables [`Row`] data types validation against the database schema
@@ -735,5 +764,61 @@ mod client_tests {
         let client_clone = client.clone();
         let client = client.with_option("async_insert", "1");
         assert_ne!(client.options, client_clone.options,);
+    }
+}
+
+#[cfg(test)]
+mod query_flags_tests {
+    use super::*;
+    use crate::query::QI;
+
+    #[test]
+    fn test_query_with_flags() {
+        let client = Client::default();
+
+        // Test query with BIND flag
+        let query_bind = client.query_with_flags::<{ QI::BIND }>("SELECT * FROM test WHERE id = ?");
+        assert_eq!(
+            format!("{}", query_bind.sql_display()),
+            "SELECT * FROM test WHERE id = ?"
+        );
+
+        // Test query with FIELDS flag
+        let query_fields = client.query_with_flags::<{ QI::FIELDS }>("SELECT ?fields FROM test");
+        assert_eq!(
+            format!("{}", query_fields.sql_display()),
+            "SELECT ?fields FROM test"
+        );
+
+        // Test query with combined flags
+        let query_combined = client
+            .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM test WHERE id = ?");
+        assert_eq!(
+            format!("{}", query_combined.sql_display()),
+            "SELECT ?fields FROM test WHERE id = ?"
+        );
+    }
+
+    #[test]
+    fn test_binding_behavior_with_flags() {
+        let client = Client::default();
+
+        // Test with BIND flag - should work normally
+        let mut query_with_bind =
+            client.query_with_flags::<{ QI::BIND }>("SELECT * FROM test WHERE id = ?");
+        query_with_bind = query_with_bind.bind(42);
+        assert_eq!(
+            format!("{}", query_with_bind.sql_display()),
+            "SELECT * FROM test WHERE id = 42"
+        );
+
+        // Test without BIND flag - should skip binding
+        let mut query_without_bind =
+            client.query_with_flags::<{ QI::NONE }>("SELECT * FROM test WHERE id = ?");
+        query_without_bind = query_without_bind.bind(42); // This should be skipped
+        assert_eq!(
+            format!("{}", query_without_bind.sql_display()),
+            "SELECT * FROM test WHERE id = ?"
+        );
     }
 }

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,0 +1,11 @@
+// Suppress Clippy warning due to identical names for the folder and file (`query`)
+#![allow(clippy::module_inception)]
+
+// Declare the submodules
+mod query;
+mod query_flags;
+
+// Re-export public items
+pub use crate::cursors::{BytesCursor, RowCursor};
+pub use query::Query;
+pub use query_flags::QI;

--- a/src/query/query_flags.rs
+++ b/src/query/query_flags.rs
@@ -1,0 +1,37 @@
+/// Query interpolation flags for controlling SQL template processing.
+///
+/// This struct provides compile-time constants that control how SQL templates
+/// are processed, specifically for `?` parameter binding and `?fields` substitution.
+#[derive(Clone)]
+pub struct QI;
+
+impl QI {
+    /// No interpolation features enabled. `?` becomes `NULL`, `?fields` is skipped. Implemented only for test purposes
+    pub const NONE: u8 = 0;
+
+    /// Enable `?fields` substitution with struct field names.
+    pub const FIELDS: u8 = 0b0001;
+
+    /// Enable `?` parameter binding with `.bind()` method.
+    pub const BIND: u8 = 0b0010;
+
+    /// Default flags used by `.query()` method.
+    ///
+    /// By default, only `?fields` substitution is enabled. Parameter binding (`?`)
+    /// is opt-in via `Client::query_with_flags`.
+    pub const DEFAULT: u8 = QI::FIELDS;
+
+    /// All interpolation features enabled.
+    pub const ALL: u8 = QI::FIELDS | QI::BIND;
+
+    /// Compile-time flag checking functions
+    #[inline(always)]
+    pub const fn has_fields(flags: u8) -> bool {
+        (flags & Self::FIELDS) != 0
+    }
+
+    #[inline(always)]
+    pub const fn has_bind(flags: u8) -> bool {
+        (flags & Self::BIND) != 0
+    }
+}

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -2,6 +2,7 @@ use std::fmt::{self, Display, Write};
 
 use crate::{
     error::{Error, Result},
+    query::QI,
     row::{self, Row},
 };
 
@@ -113,7 +114,7 @@ impl SqlBuilder {
         }
     }
 
-    pub(crate) fn finish(mut self) -> Result<String> {
+    pub(crate) fn finish(mut self, interp_flags: u8) -> Result<String> {
         let mut sql = String::new();
 
         if let Self::InProgress(parts, _) = &self {
@@ -121,12 +122,31 @@ impl SqlBuilder {
                 match part {
                     Part::Text(text) => sql.push_str(text),
                     Part::Arg => {
-                        self.error("unbound query argument");
-                        break;
+                        if QI::has_bind(interp_flags) {
+                            // Error on unbound arguments when BIND flag is set
+                            self.error("unbound query argument");
+                            break;
+                        } else {
+                            // Push NULL as placeholder when BIND flag is not set
+                            eprintln!(
+                                "warning: bind() called but QI::BIND flag not set, using NULL for query: {}",
+                                self
+                            );
+                            sql.push_str("NULL");
+                        }
                     }
                     Part::Fields => {
-                        self.error("unbound query argument ?fields");
-                        break;
+                        if QI::has_fields(interp_flags) {
+                            self.error("unbound query argument ?fields");
+                            break;
+                        } else {
+                            // Skip ?fields binding entirely when FIELDS flag is not set
+                            eprintln!(
+                                "warning: use QI::FIELDS template flag, ?fields skipped for query: {}",
+                                self
+                            );
+                            // Don't push anything - just skip this part
+                        }
                     }
                 }
             }
@@ -194,9 +214,26 @@ mod tests {
         );
 
         assert_eq!(
-            sql.finish().unwrap(),
+            sql.finish(QI::BIND).unwrap(),
             r"SELECT `a`,`b` FROM test WHERE a = 'foo' AND b < 42"
         );
+    }
+
+    #[test]
+    fn skipped_fields() {
+        // Test that ?fields is skipped when FIELDS flag is not set
+        let mut sql = SqlBuilder::new("SELECT ?fields FROM test WHERE id = ?");
+        sql.bind_arg(42);
+
+        // Without QI::FIELDS flag, ?fields should be skipped entirely
+        // The bound ? becomes 42 as expected
+        let result = sql.finish(QI::NONE).unwrap();
+        assert_eq!(result, "SELECT  FROM test WHERE id = 42");
+
+        // Test case with unbound ? - should become NULL when BIND flag not set
+        let sql2 = SqlBuilder::new("SELECT ?fields FROM test WHERE id = ?");
+        let result2 = sql2.finish(QI::NONE).unwrap();
+        assert_eq!(result2, "SELECT  FROM test WHERE id = NULL");
     }
 
     #[test]
@@ -205,7 +242,7 @@ mod tests {
             let mut sql = SqlBuilder::new("SELECT ?fields FROM test WHERE a IN ?");
             sql.bind_arg(arg);
             sql.bind_fields::<Row>();
-            assert_eq!(sql.finish().unwrap(), expected);
+            assert_eq!(sql.finish(QI::BIND).unwrap(), expected);
         }
 
         const ARGS: &[&str] = &["bar", "baz", "foobar"];
@@ -228,7 +265,7 @@ mod tests {
         sql.bind_arg(&["a?b", "c?"][..]);
         sql.bind_arg("a?");
         assert_eq!(
-            sql.finish().unwrap(),
+            sql.finish(QI::BIND).unwrap(),
             r"SELECT 1 FROM test WHERE a IN ['a?b','c?'] AND b = 'a?'"
         );
     }
@@ -237,7 +274,7 @@ mod tests {
     fn question_escape() {
         let sql = SqlBuilder::new("SELECT 1 FROM test WHERE a IN 'a??b'");
         assert_eq!(
-            sql.finish().unwrap(),
+            sql.finish(QI::BIND).unwrap(),
             r"SELECT 1 FROM test WHERE a IN 'a?b'"
         );
     }
@@ -246,39 +283,51 @@ mod tests {
     fn option_as_null() {
         let mut sql = SqlBuilder::new("SELECT 1 FROM test WHERE a = ?");
         sql.bind_arg(None::<u32>);
-        assert_eq!(sql.finish().unwrap(), r"SELECT 1 FROM test WHERE a = NULL");
+        assert_eq!(
+            sql.finish(QI::BIND).unwrap(),
+            r"SELECT 1 FROM test WHERE a = NULL"
+        );
     }
 
     #[test]
     fn option_as_value() {
         let mut sql = SqlBuilder::new("SELECT 1 FROM test WHERE a = ?");
         sql.bind_arg(Some(1u32));
-        assert_eq!(sql.finish().unwrap(), r"SELECT 1 FROM test WHERE a = 1");
+        assert_eq!(
+            sql.finish(QI::BIND).unwrap(),
+            r"SELECT 1 FROM test WHERE a = 1"
+        );
     }
 
     #[test]
     fn failures() {
         let mut sql = SqlBuilder::new("SELECT 1");
         sql.bind_arg(42);
-        let err = sql.finish().unwrap_err();
+        let err = sql.finish(QI::BIND).unwrap_err();
         assert!(err.to_string().contains("all arguments are already bound"));
 
         let mut sql = SqlBuilder::new("SELECT ?fields");
         sql.bind_fields::<Unnamed>();
-        let err = sql.finish().unwrap_err();
+        let err = sql.finish(QI::BIND | QI::FIELDS).unwrap_err();
         assert!(
             err.to_string()
                 .contains("argument ?fields cannot be used with non-struct row types")
         );
 
+        //new changes ->
+        // let err = sql.finish().unwrap_err();
+        // assert!(
+        //     err.to_string()
+        //         .contains("argument ?fields cannot be used with non-struct row types")
+        // );
         let mut sql = SqlBuilder::new("SELECT a FROM test WHERE b = ? AND c = ?");
         sql.bind_arg(42);
-        let err = sql.finish().unwrap_err();
+        let err = sql.finish(QI::BIND).unwrap_err();
         assert!(err.to_string().contains("unbound query argument"));
 
         let mut sql = SqlBuilder::new("SELECT ?fields FROM test WHERE b = ?");
         sql.bind_arg(42);
-        let err = sql.finish().unwrap_err();
+        let err = sql.finish(QI::BIND | QI::FIELDS).unwrap_err();
         assert!(err.to_string().contains("unbound query argument ?fields"));
     }
 }

--- a/tests/it/int128.rs
+++ b/tests/it/int128.rs
@@ -1,7 +1,7 @@
 use rand::random;
 use serde::{Deserialize, Serialize};
 
-use clickhouse::Row;
+use clickhouse::{Row, query::QI};
 
 #[tokio::test]
 async fn u128() {
@@ -51,7 +51,9 @@ async fn u128() {
     insert.end().await.unwrap();
 
     let rows = client
-        .query("SELECT ?fields FROM test WHERE id IN ? ORDER BY value")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>(
+            "SELECT ?fields FROM test WHERE id IN ? ORDER BY value",
+        )
         .bind(vec![id0, id2])
         .fetch_all::<MyRow>()
         .await
@@ -110,7 +112,9 @@ async fn i128() {
     insert.end().await.unwrap();
 
     let rows = client
-        .query("SELECT ?fields FROM test WHERE id IN ? ORDER BY value")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>(
+            "SELECT ?fields FROM test WHERE id IN ? ORDER BY value",
+        )
         .bind(vec![id0, id2])
         .fetch_all::<MyRow>()
         .await

--- a/tests/it/rbwnat_smoke.rs
+++ b/tests/it/rbwnat_smoke.rs
@@ -2,6 +2,7 @@ use crate::decimals::*;
 use crate::geo_types::{LineString, MultiLineString, MultiPolygon, Point, Polygon, Ring};
 use crate::{SimpleRow, create_simple_table, execute_statements, get_client, insert_and_select};
 use clickhouse::Row;
+use clickhouse::query::QI;
 use clickhouse::sql::Identifier;
 use fxhash::FxHashMap;
 use indexmap::IndexMap;
@@ -463,7 +464,7 @@ async fn enums() {
 
     let client = prepare_database!();
     client
-        .query(
+        .query_with_flags::<{ QI::BIND }>(
             "
             CREATE OR REPLACE TABLE ?
             (
@@ -1433,7 +1434,7 @@ async fn ephemeral_columns() {
 
     let client = prepare_database!();
     client
-        .query(
+        .query_with_flags::<{ QI::BIND }>(
             "
                 CREATE OR REPLACE TABLE ?
                 (
@@ -1468,7 +1469,7 @@ async fn ephemeral_columns() {
     insert.end().await.unwrap();
 
     let rows = client
-        .query("SELECT ?fields FROM ? ORDER BY () ASC")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ? ORDER BY () ASC")
         .bind(Identifier(table_name))
         .fetch_all::<DataSelect>()
         .await
@@ -1524,7 +1525,7 @@ async fn materialized_columns() {
     .await;
 
     let rows = client
-        .query("SELECT ?fields FROM ? ORDER BY x ASC")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ? ORDER BY x ASC")
         .bind(Identifier(table_name))
         .fetch_all::<DataWithMaterialized>()
         .await
@@ -1559,7 +1560,7 @@ async fn materialized_columns() {
     insert.end().await.unwrap();
 
     let rows_after_insert = client
-        .query("SELECT ?fields FROM ? ORDER BY x ASC")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ? ORDER BY x ASC")
         .bind(Identifier(table_name))
         .fetch_all::<DataWithMaterialized>()
         .await
@@ -1615,7 +1616,7 @@ async fn alias_columns() {
     .await;
 
     let rows = client
-        .query("SELECT ?fields FROM ?")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ?")
         .bind(Identifier(table_name))
         .fetch_all::<Data>()
         .await
@@ -1647,7 +1648,7 @@ async fn alias_columns() {
     insert.end().await.unwrap();
 
     let rows_after_insert = client
-        .query("SELECT ?fields FROM ? ORDER BY id ASC")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ? ORDER BY id ASC")
         .bind(Identifier(table_name))
         .fetch_all::<Data>()
         .await

--- a/tests/it/user_agent.rs
+++ b/tests/it/user_agent.rs
@@ -1,7 +1,10 @@
 use crate::{SimpleRow, create_simple_table, flush_query_log};
-use clickhouse::Client;
-use clickhouse::sql::Identifier;
+use clickhouse::{Client, query::QI, sql::Identifier};
 
+//new changes
+// use crate::{SimpleRow, create_simple_table, flush_query_log};
+// use clickhouse::Client;
+// use clickhouse::sql::Identifier;
 const PKG_VER: &str = env!("CARGO_PKG_VERSION");
 const RUST_VER: &str = env!("CARGO_PKG_RUST_VERSION");
 const OS: &str = std::env::consts::OS;
@@ -45,7 +48,7 @@ async fn assert_queries_user_agents(client: &Client, table_name: &str, expected_
     insert.end().await.unwrap();
 
     let rows = client
-        .query("SELECT ?fields FROM ?")
+        .query_with_flags::<{ QI::FIELDS | QI::BIND }>("SELECT ?fields FROM ?")
         .bind(Identifier(table_name))
         .fetch_all::<SimpleRow>()
         .await


### PR DESCRIPTION
## Summary
Add support for explicit interpolation flags to specify exactly which interpolation features should be enabled in the query.
Add integration tests for possible flag combinations.
Update README.

Reference: https://github.com/ClickHouse/clickhouse-rs/issues/157
