### PR TITLE
Fix handle comments and semicolons in SQL queries (#268)

### DIFF
--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -177,6 +177,7 @@ mod ip;
 mod mock;
 mod nested;
 mod query;
+mod query_syntax;
 mod rbwnat;
 mod time;
 mod user_agent;

--- a/tests/it/query_syntax.rs
+++ b/tests/it/query_syntax.rs
@@ -1,11 +1,4 @@
 #[tokio::test]
-async fn query_with_semicolon() {
-    let client = prepare_database!();
-    let value = client.query("SELECT 1;").fetch_one::<u8>().await.unwrap();
-    assert_eq!(value, 1);
-}
-
-#[tokio::test]
 async fn query_with_tail_comment() {
     let client = prepare_database!();
     let value = client
@@ -47,6 +40,116 @@ async fn query_with_mid_comment() {
         .await
         .unwrap();
     assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_comment_multiline() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT *\nFROM system.numbers\n/* This is:\na multiline comment\n*/\nLIMIT 3")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_comment_utf8() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT * FROM system.numbers LIMIT 3 -- проверка данных 测试 ;;;;;")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_comment_multiline_unterminated() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT '/* unterminated' AS s")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "/* unterminated");
+}
+
+#[tokio::test]
+async fn query_with_comment_syntax() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT '-- not a comment /* not a comment */'")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "-- not a comment /* not a comment */");
+}
+
+#[tokio::test]
+async fn query_with_comment_combined() {
+    let client = prepare_database!();
+    let value = client
+        .query("--comment\nSELECT *\n--comment\n/*\nпроверка\t;;\r\n;;\n*/\nFROM (select 1)\n;")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_semicolon() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT * FROM system.numbers LIMIT 3;")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_semicolon_trailing() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT * FROM system.numbers LIMIT 3;;;;;;;;;;;;;;;;;")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_semicolon_in_comment() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT * FROM system.numbers LIMIT 3 -- comment with ;;")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_semicolon_in_multiline_comment() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT * FROM system.numbers LIMIT 3 /*\n * comment with --\n * and ; inside\n*/")
+        .fetch_all::<u64>()
+        .await
+        .unwrap();
+    assert_eq!(value, [0, 1, 2]);
+}
+
+#[tokio::test]
+async fn query_with_semicolon_allowed() {
+    let client = prepare_database!();
+    let value = client
+        .query("SELECT ';;';;")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, ";;");
 }
 
 #[tokio::test]

--- a/tests/it/query_syntax.rs
+++ b/tests/it/query_syntax.rs
@@ -1,0 +1,76 @@
+#[tokio::test]
+async fn query_with_semicolon() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1;").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_comment() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1 \n --comment").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_head_comment() {
+    let client = prepare_database!();
+    let value = client.query("--comment\nSELECT 1").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_head_and_tail_comment() {
+    let client = prepare_database!();
+    let value = client.query("--comment\nSELECT 1\n--comment").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_mid_comment() {
+    let client = prepare_database!();
+    let value = client.query("SELECT \n--comment\n 1").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_newline() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1\n").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_space() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1 ").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_tab() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1\t").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_carriage_return() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1\r").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_carriage_return_newline() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1\r\n").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn query_with_tail_carriage_return_space() {
+    let client = prepare_database!();
+    let value = client.query("SELECT 1\r ").fetch_one::<u8>().await.unwrap();
+    assert_eq!(value, 1);
+}

--- a/tests/it/query_syntax.rs
+++ b/tests/it/query_syntax.rs
@@ -8,28 +8,44 @@ async fn query_with_semicolon() {
 #[tokio::test]
 async fn query_with_tail_comment() {
     let client = prepare_database!();
-    let value = client.query("SELECT 1 \n --comment").fetch_one::<u8>().await.unwrap();
+    let value = client
+        .query("SELECT 1 \n --comment")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
     assert_eq!(value, 1);
 }
 
 #[tokio::test]
 async fn query_with_head_comment() {
     let client = prepare_database!();
-    let value = client.query("--comment\nSELECT 1").fetch_one::<u8>().await.unwrap();
+    let value = client
+        .query("--comment\nSELECT 1")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
     assert_eq!(value, 1);
 }
 
 #[tokio::test]
 async fn query_with_head_and_tail_comment() {
     let client = prepare_database!();
-    let value = client.query("--comment\nSELECT 1\n--comment").fetch_one::<u8>().await.unwrap();
+    let value = client
+        .query("--comment\nSELECT 1\n--comment")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
     assert_eq!(value, 1);
 }
 
 #[tokio::test]
 async fn query_with_mid_comment() {
     let client = prepare_database!();
-    let value = client.query("SELECT \n--comment\n 1").fetch_one::<u8>().await.unwrap();
+    let value = client
+        .query("SELECT \n--comment\n 1")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
     assert_eq!(value, 1);
 }
 
@@ -64,7 +80,11 @@ async fn query_with_tail_carriage_return() {
 #[tokio::test]
 async fn query_with_tail_carriage_return_newline() {
     let client = prepare_database!();
-    let value = client.query("SELECT 1\r\n").fetch_one::<u8>().await.unwrap();
+    let value = client
+        .query("SELECT 1\r\n")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
     assert_eq!(value, 1);
 }
 


### PR DESCRIPTION
## Summary

This PR fixes issue #268 by properly handling comments and semicolons at the end of SQL queries.

Changes:

- Fixed FORMAT clause insertion to place it before trailing semicolons, comments and whitespace, not after
- Added tests for various edge cases with comments and semicolons

However, it does not support nested comments (like `"SELECT 1 /* outer /* nested */ comment */"`) at the moment.

Happy to discuss alternative approaches if there are concerns about this implementation.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later

Based on #267
Closes #268