### PR TITLE
chore: add Debug derive to [Client] type

### DIFF
--- a/src/http_client.rs
+++ b/src/http_client.rs
@@ -22,7 +22,7 @@ use crate::request_body::RequestBody;
 /// future (e.g. to support more runtimes, not only tokio). Thus, prefer to open
 /// a feature request instead of implementing this trait manually.
 #[sealed]
-pub trait HttpClient: Send + Sync + 'static {
+pub trait HttpClient: Send + Sync + std::fmt::Debug + 'static {
     fn request(&self, req: Request<RequestBody>) -> ResponseFuture;
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,7 +37,7 @@ mod rowbinary;
 mod ticks;
 
 /// A client containing HTTP pool.
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Client {
     http: Arc<dyn HttpClient>,
 
@@ -54,7 +54,7 @@ pub struct Client {
     mocked: bool,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 struct ProductInfo {
     name: String,
     version: String,


### PR DESCRIPTION
## Summary

I always use Debug derive for quick problem tracking, but errors occur because this `Client` doesn't have Debug implemented.

<img width="778" height="363" alt="image" src="https://github.com/user-attachments/assets/9d2c9c43-ec91-432b-a714-f013e3c02b6b" />



## Checklist
Delete items not relevant to your PR:
- [ ] Unit and integration tests covering the common scenarios were added
- [ ] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [ ] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
