### PR TITLE
chore(types): upgrade `thiserror` to v2

### DIFF
--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -13,5 +13,5 @@ rust-version.workspace = true
 missing_docs = "warn"
 
 [dependencies]
-thiserror = "1.0.16"
+thiserror = "2.0"
 bytes = "1.10.1"


### PR DESCRIPTION
## Summary

This upgrades `thiserror` to v2 in `clickhouse-types`. `clickhouse` is already using v2, so this avoids the duplicate dependency version.

## Checklist

- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
