### PR TITLE
Implement support for jiff

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition.workspace = true
 rust-version.workspace = true
 
 [workspace]
-members = ["ext-arrow", "macros", "types"]
+members = ["clickhouse-jiff", "ext-arrow", "macros", "types"]
 # `rust-version`-aware dependency resolution;
 # applies to all workspace members
 resolver = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -174,6 +174,9 @@ opentelemetry-http = { version = "0.31.0", optional = true }
 clickhouse-macros = { version = "0.3.0", path = "macros" }
 clickhouse-ext-arrow = { path = "ext-arrow" }
 
+clickhouse-jiff = { path = "clickhouse-jiff" }
+jiff = { version = "0.2", default-features = false }
+
 criterion = "0.6"
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["full", "test-util", "io-util"] }

--- a/clickhouse-jiff/Cargo.toml
+++ b/clickhouse-jiff/Cargo.toml
@@ -12,7 +12,3 @@ rust-version.workspace = true
 [dependencies]
 jiff = { version = "0.2.28", default-features = false }
 serde_core = { version = "1.0.228", default-features = false }
-
-[build-dependencies]
-clickhouse = { version = "0.15.1", path = ".." }
-tokio = "1"

--- a/clickhouse-jiff/Cargo.toml
+++ b/clickhouse-jiff/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "clickhouse-jiff"
+description = "Integration for Jiff with ClickHouse"
+version = "0.1.0"
+authors.workspace = true
+repository.workspace = true
+homepage.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+jiff = { version = "0.2.28", default-features = false }
+serde_core = { version = "1.0.228", default-features = false }
+
+[build-dependencies]
+clickhouse = { version = "0.15.1", path = ".." }
+tokio = "1"

--- a/clickhouse-jiff/src/lib.rs
+++ b/clickhouse-jiff/src/lib.rs
@@ -27,6 +27,8 @@ driver does not introspect that information.
 
 */
 
+#![forbid(missing_docs, unsafe_code)]
+
 mod wrappers;
 
 pub use self::wrappers::*;

--- a/clickhouse-jiff/src/lib.rs
+++ b/clickhouse-jiff/src/lib.rs
@@ -1,3 +1,32 @@
+/*!
+
+This crate provides wrappers for various types from [`jiff`]
+that, at the moment, provide implementations of [`serde`]'s
+`Deserialize` and `Serialize` that are compatible with [`clickhouse`].
+
+# Available types
+
+* [`Date16`] - wraps [`jiff::civil::Date`], corresponds to ClickHouse's [`Date`](https://clickhouse.com/docs/sql-reference/data-types/date);
+* [`Date32`] - wraps [`jiff::civil::Date`], corresponds to ClickHouse's [`Date32`](https://clickhouse.com/docs/sql-reference/data-types/date32);
+* [`SignedDuration32`] - wraps [`jiff::SignedDuration`], corresponds to ClickHouse's [`Time`](https://clickhouse.com/docs/sql-reference/data-types/time);
+* [`SignedDuration64<precision>`](SignedDuration64) - wraps [`jiff::SignedDuration`], corresponds to ClickHouse's [`Time64(precision)`](https://clickhouse.com/docs/sql-reference/data-types/time64);
+* [`Timestamp32`] - wraps [`jiff::Timestamp`], corresponds to ClickHouse's [`DateTime`](https://clickhouse.com/docs/sql-reference/data-types/datetime);
+* [`Timestamp64<precision>`](Timestamp64) - wraps [`jiff::Timestamp`], corresponds to ClickHouse's [`DateTime64(precision)`](https://clickhouse.com/docs/sql-reference/data-types/datetime64).
+
+# Warning regarding 64-bit types
+
+It is important to make sure that the precision of a wrapper
+matches that of a column.
+
+Failure to do so **will** cause data corruption, since the official
+driver does not introspect that information.
+
+[`clickhouse`]: https://docs.rs/clickhouse
+[`jiff`]: https://docs.rs/jiff
+[`serde`]: https://docs.rs/serde
+
+*/
+
 mod wrappers;
 
 pub use self::wrappers::*;

--- a/clickhouse-jiff/src/lib.rs
+++ b/clickhouse-jiff/src/lib.rs
@@ -1,0 +1,3 @@
+mod wrappers;
+
+pub use self::wrappers::*;

--- a/clickhouse-jiff/src/lib.rs
+++ b/clickhouse-jiff/src/lib.rs
@@ -1,8 +1,8 @@
 /*!
 
 This crate provides wrappers for various types from [`jiff`]
-that, at the moment, provide implementations of [`serde`]'s
-`Deserialize` and `Serialize` that are compatible with [`clickhouse`].
+that, at the moment, implement [`serde`]'s `Deserialize` and `Serialize`
+in a way that is compatible with [`clickhouse`].
 
 # Available types
 

--- a/clickhouse-jiff/src/wrappers/date16.rs
+++ b/clickhouse-jiff/src/wrappers/date16.rs
@@ -26,6 +26,14 @@ impl error::Error for Date16OutOfRange {}
 const FROM: jiff::civil::Date = jiff::civil::Date::constant(1970, 1, 1);
 const TO: jiff::civil::Date = jiff::civil::Date::constant(2149, 6, 6);
 
+impl Date16 {
+    /// Convert `Date16` to the underlying type.
+    #[inline]
+    pub fn into_inner(self) -> jiff::civil::Date {
+        self.0
+    }
+}
+
 impl TryFrom<jiff::civil::Date> for Date16 {
     type Error = Date16OutOfRange;
     fn try_from(value: jiff::civil::Date) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/date16.rs
+++ b/clickhouse-jiff/src/wrappers/date16.rs
@@ -1,0 +1,83 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::civil::Date`]
+/// that corresponds to `Date` in ClickHouse.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Date16(jiff::civil::Date);
+
+/// An error that occurs when [`jiff::civil::Date`]
+/// cannot be represented as a `Date` in ClickHouse.
+#[derive(Debug)]
+pub struct Date16OutOfRange;
+
+impl fmt::Display for Date16OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Date is out of range, valid values are [1970-01-01, 2149-06-06].")
+    }
+}
+
+impl error::Error for Date16OutOfRange {}
+
+const FROM: jiff::civil::Date = jiff::civil::Date::constant(1970, 1, 1);
+const TO: jiff::civil::Date = jiff::civil::Date::constant(2149, 6, 6);
+
+impl TryFrom<jiff::civil::Date> for Date16 {
+    type Error = Date16OutOfRange;
+    fn try_from(value: jiff::civil::Date) -> Result<Self, Self::Error> {
+        if value >= FROM && value <= TO {
+            Ok(Self(value))
+        } else {
+            Err(Date16OutOfRange)
+        }
+    }
+}
+
+impl From<Date16> for jiff::civil::Date {
+    #[inline]
+    fn from(value: Date16) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for Date16 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Possible values are [0, 65535], the whole u16 range.
+        let days = (self.0.duration_since(FROM).as_hours() / 24) as u16;
+        days.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Date16 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        struct DateVisitor;
+
+        impl<'de> Visitor<'de> for DateVisitor {
+            type Value = Date16;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a u16 representation of a ClickHouse Date")
+            }
+
+            fn visit_u16<E>(self, v: u16) -> Result<Self::Value, E>
+            where
+                E: serde_core::de::Error,
+            {
+                let date = FROM + jiff::SignedDuration::from_hours(i64::from(v) * 24);
+                Ok(Date16(date))
+            }
+        }
+
+        deserializer.deserialize_u16(DateVisitor)
+    }
+}

--- a/clickhouse-jiff/src/wrappers/date16.rs
+++ b/clickhouse-jiff/src/wrappers/date16.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -66,7 +66,7 @@ impl Serialize for Date16 {
 impl<'de> Deserialize<'de> for Date16 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde_core::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct DateVisitor;
 

--- a/clickhouse-jiff/src/wrappers/date16.rs
+++ b/clickhouse-jiff/src/wrappers/date16.rs
@@ -16,7 +16,7 @@ pub struct Date16(jiff::civil::Date);
 pub struct Date16OutOfRange;
 
 impl fmt::Display for Date16OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Date is out of range, valid values are [1970-01-01, 2149-06-06].")
     }
 }
@@ -65,7 +65,7 @@ impl<'de> Deserialize<'de> for Date16 {
         impl<'de> Visitor<'de> for DateVisitor {
             type Value = Date16;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a u16 representation of a ClickHouse Date")
             }
 

--- a/clickhouse-jiff/src/wrappers/date32.rs
+++ b/clickhouse-jiff/src/wrappers/date32.rs
@@ -27,6 +27,14 @@ const ORIGIN: jiff::civil::Date = jiff::civil::Date::constant(1970, 1, 1);
 const FROM: jiff::civil::Date = jiff::civil::Date::constant(1900, 1, 1);
 const TO: jiff::civil::Date = jiff::civil::Date::constant(2299, 12, 31);
 
+impl Date32 {
+    /// Convert `Date32` to the underlying type.
+    #[inline]
+    pub fn into_inner(self) -> jiff::civil::Date {
+        self.0
+    }
+}
+
 impl TryFrom<jiff::civil::Date> for Date32 {
     type Error = Date32OutOfRange;
     fn try_from(value: jiff::civil::Date) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/date32.rs
+++ b/clickhouse-jiff/src/wrappers/date32.rs
@@ -16,7 +16,7 @@ pub struct Date32(jiff::civil::Date);
 pub struct Date32OutOfRange;
 
 impl fmt::Display for Date32OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Date is out of range, valid values are [1900-01-01, 2299-12-31].")
     }
 }
@@ -66,7 +66,7 @@ impl<'de> Deserialize<'de> for Date32 {
         impl<'de> Visitor<'de> for DateVisitor {
             type Value = Date32;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("an i32 representation of a ClickHouse Date32")
             }
 

--- a/clickhouse-jiff/src/wrappers/date32.rs
+++ b/clickhouse-jiff/src/wrappers/date32.rs
@@ -1,0 +1,84 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::civil::Date`]
+/// that corresponds to `Date32` in ClickHouse.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Date32(jiff::civil::Date);
+
+/// An error that occurs when [`jiff::civil::Date`]
+/// cannot be represented as a `Date32` in ClickHouse.
+#[derive(Debug)]
+pub struct Date32OutOfRange;
+
+impl fmt::Display for Date32OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Date is out of range, valid values are [1900-01-01, 2299-12-31].")
+    }
+}
+
+impl error::Error for Date32OutOfRange {}
+
+const ORIGIN: jiff::civil::Date = jiff::civil::Date::constant(1970, 1, 1);
+const FROM: jiff::civil::Date = jiff::civil::Date::constant(1900, 1, 1);
+const TO: jiff::civil::Date = jiff::civil::Date::constant(2299, 12, 31);
+
+impl TryFrom<jiff::civil::Date> for Date32 {
+    type Error = Date32OutOfRange;
+    fn try_from(value: jiff::civil::Date) -> Result<Self, Self::Error> {
+        if value >= FROM && value <= TO {
+            Ok(Self(value))
+        } else {
+            Err(Date32OutOfRange)
+        }
+    }
+}
+
+impl From<Date32> for jiff::civil::Date {
+    #[inline]
+    fn from(value: Date32) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for Date32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Possible values are [-25567, 120529], which do fit in an i32.
+        let days = (self.0.duration_since(ORIGIN).as_hours() / 24) as i32;
+        days.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Date32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        struct DateVisitor;
+
+        impl<'de> Visitor<'de> for DateVisitor {
+            type Value = Date32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an i32 representation of a ClickHouse Date32")
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+            where
+                E: serde_core::de::Error,
+            {
+                let date = ORIGIN + jiff::SignedDuration::from_hours(i64::from(v) * 24);
+                Ok(Date32(date))
+            }
+        }
+
+        deserializer.deserialize_i32(DateVisitor)
+    }
+}

--- a/clickhouse-jiff/src/wrappers/date32.rs
+++ b/clickhouse-jiff/src/wrappers/date32.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -67,7 +67,7 @@ impl Serialize for Date32 {
 impl<'de> Deserialize<'de> for Date32 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde_core::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct DateVisitor;
 

--- a/clickhouse-jiff/src/wrappers/mod.rs
+++ b/clickhouse-jiff/src/wrappers/mod.rs
@@ -1,6 +1,3 @@
-#![forbid(unsafe_code)]
-#![forbid(missing_docs)]
-
 mod date16;
 mod date32;
 mod signed_duration32;

--- a/clickhouse-jiff/src/wrappers/mod.rs
+++ b/clickhouse-jiff/src/wrappers/mod.rs
@@ -1,0 +1,16 @@
+#![forbid(unsafe_code)]
+#![forbid(missing_docs)]
+
+mod date16;
+mod date32;
+mod signed_duration32;
+mod signed_duration64;
+mod timestamp32;
+mod timestamp64;
+
+pub use date16::*;
+pub use date32::*;
+pub use signed_duration32::*;
+pub use signed_duration64::*;
+pub use timestamp32::*;
+pub use timestamp64::*;

--- a/clickhouse-jiff/src/wrappers/signed_duration32.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration32.rs
@@ -26,6 +26,14 @@ impl error::Error for SignedDuration32OutOfRange {}
 const FROM: jiff::SignedDuration = jiff::SignedDuration::new(-3599999, 0);
 const TO: jiff::SignedDuration = jiff::SignedDuration::new(3599999, 0);
 
+impl SignedDuration32 {
+    /// Convert `SignedDuration32` to the underlying type.
+    #[inline]
+    pub fn into_inner(self) -> jiff::SignedDuration {
+        self.0
+    }
+}
+
 impl TryFrom<jiff::SignedDuration> for SignedDuration32 {
     type Error = SignedDuration32OutOfRange;
     fn try_from(value: jiff::SignedDuration) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/signed_duration32.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration32.rs
@@ -16,7 +16,7 @@ pub struct SignedDuration32(jiff::SignedDuration);
 pub struct SignedDuration32OutOfRange;
 
 impl fmt::Display for SignedDuration32OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("SignedDuration is out of range, valid values are [-999:59:59, 999:59:59].")
     }
 }
@@ -65,7 +65,7 @@ impl<'de> Deserialize<'de> for SignedDuration32 {
         impl<'de> Visitor<'de> for DurationVisitor {
             type Value = SignedDuration32;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("an i32 representation of a ClickHouse Time")
             }
 

--- a/clickhouse-jiff/src/wrappers/signed_duration32.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration32.rs
@@ -1,0 +1,83 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::SignedDuration`]
+/// that corresponds to `Time` in ClickHouse.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct SignedDuration32(jiff::SignedDuration);
+
+/// An error that occurs when [`jiff::SignedDuration`]
+/// cannot be represented as a `Time` in ClickHouse.
+#[derive(Debug)]
+pub struct SignedDuration32OutOfRange;
+
+impl fmt::Display for SignedDuration32OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SignedDuration is out of range, valid values are [-999:59:59, 999:59:59].")
+    }
+}
+
+impl error::Error for SignedDuration32OutOfRange {}
+
+const FROM: jiff::SignedDuration = jiff::SignedDuration::new(-3599999, 0);
+const TO: jiff::SignedDuration = jiff::SignedDuration::new(3599999, 0);
+
+impl TryFrom<jiff::SignedDuration> for SignedDuration32 {
+    type Error = SignedDuration32OutOfRange;
+    fn try_from(value: jiff::SignedDuration) -> Result<Self, Self::Error> {
+        if value >= FROM && value <= TO {
+            Ok(Self(value))
+        } else {
+            Err(SignedDuration32OutOfRange)
+        }
+    }
+}
+
+impl From<SignedDuration32> for jiff::SignedDuration {
+    #[inline]
+    fn from(value: SignedDuration32) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for SignedDuration32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // Possible values are [-3599999, 3599999], which do fit in an i32.
+        let ts = self.0.as_secs() as i32;
+        ts.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for SignedDuration32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        struct DurationVisitor;
+
+        impl<'de> Visitor<'de> for DurationVisitor {
+            type Value = SignedDuration32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("an i32 representation of a ClickHouse Time")
+            }
+
+            fn visit_i32<E>(self, v: i32) -> Result<Self::Value, E>
+            where
+                E: serde_core::de::Error,
+            {
+                let ts = jiff::SignedDuration::from_secs(v.into());
+                Ok(SignedDuration32(ts))
+            }
+        }
+
+        deserializer.deserialize_i32(DurationVisitor)
+    }
+}

--- a/clickhouse-jiff/src/wrappers/signed_duration32.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration32.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -66,7 +66,7 @@ impl Serialize for SignedDuration32 {
 impl<'de> Deserialize<'de> for SignedDuration32 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde_core::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct DurationVisitor;
 

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -8,10 +8,10 @@ use serde_core::{
 /// that corresponds to `Time64` in ClickHouse.
 ///
 /// Supported precision:
-/// * SignedDuration64<0> - seconds;
-/// * SignedDuration64<3> - milliseconds;
-/// * SignedDuration64<6> - microseconds;
-/// * SignedDuration64<9> - nanoseconds.
+/// * `SignedDuration64<0>` - seconds;
+/// * `SignedDuration64<3>` - milliseconds;
+/// * `SignedDuration64<6>` - microseconds;
+/// * `SignedDuration64<9>` - nanoseconds.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct SignedDuration64<const PRECISION: u8>(jiff::SignedDuration);

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -29,7 +29,7 @@ impl fmt::Display for SignedDuration64OutOfRange {
 
 impl error::Error for SignedDuration64OutOfRange {}
 
-const FROM: jiff::SignedDuration = jiff::SignedDuration::new(-3599999, 999999999);
+const FROM: jiff::SignedDuration = jiff::SignedDuration::new(-3599999, -999999999);
 const TO: jiff::SignedDuration = jiff::SignedDuration::new(3599999, 999999999);
 
 macro_rules! impl_signed_duration64 {

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -1,0 +1,102 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::SignedDuration`]
+/// that corresponds to `Time64` in ClickHouse.
+///
+/// Supported precision:
+/// * SignedDuration64<0> - seconds;
+/// * SignedDuration64<3> - milliseconds;
+/// * SignedDuration64<6> - microseconds;
+/// * SignedDuration64<9> - nanoseconds.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct SignedDuration64<const PRECISION: u8>(jiff::SignedDuration);
+
+/// An error that occurs when [`jiff::SignedDuration`]
+/// cannot be represented as a `Time64` in ClickHouse.
+#[derive(Debug)]
+pub struct SignedDuration64OutOfRange;
+
+impl fmt::Display for SignedDuration64OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("SignedDuration is out of range, valid values are [-999:59:59.999999999, 999:59:59.999999999].")
+    }
+}
+
+impl error::Error for SignedDuration64OutOfRange {}
+
+const FROM: jiff::SignedDuration = jiff::SignedDuration::new(-3599999, 999999999);
+const TO: jiff::SignedDuration = jiff::SignedDuration::new(3599999, 999999999);
+
+macro_rules! impl_signed_duration64 {
+    ($precision:literal, $ser_conv:ident, $de_conv:ident) => {
+        impl TryFrom<jiff::SignedDuration> for SignedDuration64<$precision> {
+            type Error = SignedDuration64OutOfRange;
+            fn try_from(value: jiff::SignedDuration) -> Result<Self, Self::Error> {
+                if value >= FROM && value <= TO {
+                    Ok(Self(value))
+                } else {
+                    Err(SignedDuration64OutOfRange)
+                }
+            }
+        }
+
+        impl From<SignedDuration64<$precision>> for jiff::SignedDuration {
+            #[inline]
+            fn from(value: SignedDuration64<$precision>) -> Self {
+                value.0
+            }
+        }
+
+        impl Serialize for SignedDuration64<$precision> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                // Even at the nanosecond precision, the range of possible values
+                // is [-3599999999999999, 3599999999999999].
+                //
+                // Therefore, it is fine to cast as_nanos() and as_micros()
+                // to i64.
+                let ts = self.0.$ser_conv() as i64;
+                ts.serialize(serializer)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for SignedDuration64<$precision> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde_core::Deserializer<'de>,
+            {
+                struct TsVisitor;
+
+                impl<'de> Visitor<'de> for TsVisitor {
+                    type Value = SignedDuration64<$precision>;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("an i64 representation of a ClickHouse Time64")
+                    }
+
+                    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+                    where
+                        E: serde_core::de::Error,
+                    {
+                        let ts = jiff::SignedDuration::$de_conv(v.into());
+                        Ok(SignedDuration64::<$precision>(ts))
+                    }
+                }
+
+                deserializer.deserialize_i64(TsVisitor)
+            }
+        }
+    };
+}
+
+impl_signed_duration64!(0, as_secs, from_secs);
+impl_signed_duration64!(3, as_millis, from_millis);
+impl_signed_duration64!(6, as_micros, from_micros);
+impl_signed_duration64!(9, as_nanos, from_nanos);

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -72,9 +72,9 @@ macro_rules! impl_signed_duration64 {
             where
                 D: serde_core::Deserializer<'de>,
             {
-                struct TsVisitor;
+                struct DurationVisitor;
 
-                impl<'de> Visitor<'de> for TsVisitor {
+                impl<'de> Visitor<'de> for DurationVisitor {
                     type Value = SignedDuration64<$precision>;
 
                     fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
@@ -90,7 +90,7 @@ macro_rules! impl_signed_duration64 {
                     }
                 }
 
-                deserializer.deserialize_i64(TsVisitor)
+                deserializer.deserialize_i64(DurationVisitor)
             }
         }
     };

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -34,6 +34,14 @@ const TO: jiff::SignedDuration = jiff::SignedDuration::new(3599999, 999999999);
 
 macro_rules! impl_signed_duration64 {
     ($precision:literal, $ser_conv:ident, $de_conv:ident) => {
+        impl SignedDuration64<$precision> {
+            #[doc = concat!("Convert `SignedDuration64<", stringify!($precision), ">` to the underlying type.")]
+            #[inline]
+            pub fn into_inner(self) -> jiff::SignedDuration {
+                self.0
+            }
+        }
+
         impl TryFrom<jiff::SignedDuration> for SignedDuration64<$precision> {
             type Error = SignedDuration64OutOfRange;
             fn try_from(value: jiff::SignedDuration) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -22,7 +22,7 @@ pub struct SignedDuration64<const PRECISION: u8>(jiff::SignedDuration);
 pub struct SignedDuration64OutOfRange;
 
 impl fmt::Display for SignedDuration64OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("SignedDuration is out of range, valid values are [-999:59:59.999999999, 999:59:59.999999999].")
     }
 }
@@ -77,7 +77,7 @@ macro_rules! impl_signed_duration64 {
                 impl<'de> Visitor<'de> for TsVisitor {
                     type Value = SignedDuration64<$precision>;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                         formatter.write_str("an i64 representation of a ClickHouse Time64")
                     }
 

--- a/clickhouse-jiff/src/wrappers/signed_duration64.rs
+++ b/clickhouse-jiff/src/wrappers/signed_duration64.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -78,7 +78,7 @@ macro_rules! impl_signed_duration64 {
         impl<'de> Deserialize<'de> for SignedDuration64<$precision> {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: serde_core::Deserializer<'de>,
+                D: Deserializer<'de>,
             {
                 struct DurationVisitor;
 

--- a/clickhouse-jiff/src/wrappers/timestamp32.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp32.rs
@@ -26,6 +26,14 @@ impl error::Error for Timestamp32OutOfRange {}
 const FROM: jiff::Timestamp = jiff::Timestamp::UNIX_EPOCH;
 const TO: jiff::Timestamp = jiff::Timestamp::constant(u32::MAX as i64, 0);
 
+impl Timestamp32 {
+    /// Convert `Timestamp32` to the underlying type.
+    #[inline]
+    pub fn into_inner(self) -> jiff::Timestamp {
+        self.0
+    }
+}
+
 impl TryFrom<jiff::Timestamp> for Timestamp32 {
     type Error = Timestamp32OutOfRange;
     fn try_from(value: jiff::Timestamp) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/timestamp32.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp32.rs
@@ -16,7 +16,7 @@ pub struct Timestamp32(jiff::Timestamp);
 pub struct Timestamp32OutOfRange;
 
 impl fmt::Display for Timestamp32OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str("Timestamp is out of range, valid values are [1970-01-01 00:00:00, 2106-02-07 06:28:15].")
     }
 }
@@ -68,7 +68,7 @@ impl<'de> Deserialize<'de> for Timestamp32 {
         impl<'de> Visitor<'de> for TsVisitor {
             type Value = Timestamp32;
 
-            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+            fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                 formatter.write_str("a u32 representation of a ClickHouse DateTime")
             }
 

--- a/clickhouse-jiff/src/wrappers/timestamp32.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp32.rs
@@ -11,7 +11,7 @@ use serde_core::{
 pub struct Timestamp32(jiff::Timestamp);
 
 /// An error that occurs when [`jiff::Timestamp`]
-/// cannot be represented as a `DateTime64` in ClickHouse.
+/// cannot be represented as a `DateTime` in ClickHouse.
 #[derive(Debug)]
 pub struct Timestamp32OutOfRange;
 

--- a/clickhouse-jiff/src/wrappers/timestamp32.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp32.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -69,7 +69,7 @@ impl Serialize for Timestamp32 {
 impl<'de> Deserialize<'de> for Timestamp32 {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
-        D: serde_core::Deserializer<'de>,
+        D: Deserializer<'de>,
     {
         struct TsVisitor;
 

--- a/clickhouse-jiff/src/wrappers/timestamp32.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp32.rs
@@ -1,0 +1,87 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::Timestamp`]
+/// that corresponds to `DateTime` in ClickHouse.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Timestamp32(jiff::Timestamp);
+
+/// An error that occurs when [`jiff::Timestamp`]
+/// cannot be represented as a `DateTime64` in ClickHouse.
+#[derive(Debug)]
+pub struct Timestamp32OutOfRange;
+
+impl fmt::Display for Timestamp32OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Timestamp is out of range, valid values are [1970-01-01 00:00:00, 2106-02-07 06:28:15].")
+    }
+}
+
+impl error::Error for Timestamp32OutOfRange {}
+
+const FROM: jiff::Timestamp = jiff::Timestamp::UNIX_EPOCH;
+const TO: jiff::Timestamp = jiff::Timestamp::constant(u32::MAX as i64, 0);
+
+impl TryFrom<jiff::Timestamp> for Timestamp32 {
+    type Error = Timestamp32OutOfRange;
+    fn try_from(value: jiff::Timestamp) -> Result<Self, Self::Error> {
+        if value >= FROM && value <= TO {
+            Ok(Self(value))
+        } else {
+            Err(Timestamp32OutOfRange)
+        }
+    }
+}
+
+impl From<Timestamp32> for jiff::Timestamp {
+    #[inline]
+    fn from(value: Timestamp32) -> Self {
+        value.0
+    }
+}
+
+impl Serialize for Timestamp32 {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        // `FROM` is defined as the Unix epoch,
+        // `TO` is defined as u32::MAX seconds since the epoch.
+        //
+        // Therefore, it is fine to cast as_second() to u32;
+        let ts = self.0.as_second() as u32;
+        ts.serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for Timestamp32 {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde_core::Deserializer<'de>,
+    {
+        struct TsVisitor;
+
+        impl<'de> Visitor<'de> for TsVisitor {
+            type Value = Timestamp32;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                formatter.write_str("a u32 representation of a ClickHouse DateTime")
+            }
+
+            fn visit_u32<E>(self, v: u32) -> Result<Self::Value, E>
+            where
+                E: serde_core::de::Error,
+            {
+                let ts = jiff::Timestamp::from_second(v as i64)
+                    .map_err(|_| E::custom("Failed to create a jiff::Timestamp"))?;
+                Ok(Timestamp32(ts))
+            }
+        }
+
+        deserializer.deserialize_u32(TsVisitor)
+    }
+}

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -88,7 +88,7 @@ macro_rules! impl_timestamp64 {
             where
                 S: Serializer,
             {
-                // `TO` is defined as `from_nanosecond(i64::MAX as i128)`.
+                // `TO_NANOSECONDS` is defined as `from_nanosecond(i64::MAX as i128)`.
                 //
                 // Therefore, it's perfectly fine to cast `as_nanosecond`
                 // to i64.

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -23,19 +23,40 @@ pub struct Timestamp64OutOfRange;
 
 impl fmt::Display for Timestamp64OutOfRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999].") // DateTime64(8)
-        f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2262-04-11 23:47:16.854775807].")
+        f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999].")
     }
 }
 
 impl error::Error for Timestamp64OutOfRange {}
 
+/// An error that occurs when [`jiff::Timestamp`]
+/// cannot be represented as a `DateTime64(9)` in ClickHouse.
+#[derive(Debug)]
+pub struct Timestamp64NanosecondsOutOfRange;
+
+impl fmt::Display for Timestamp64NanosecondsOutOfRange {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2262-04-11 23:47:16.854775807].")
+    }
+}
+
+impl error::Error for Timestamp64NanosecondsOutOfRange {}
+
 const FROM: jiff::Timestamp = jiff::Timestamp::constant(-2208988800, 0);
-// const TO: jiff::Timestamp = jiff::Timestamp::constant(10413791999, 999999990); // DateTime64(8)
-const TO: jiff::Timestamp = jiff::Timestamp::constant(9223372036, 854775807);
+const TO: jiff::Timestamp = jiff::Timestamp::constant(10413791999, 999999990); // Datetime64(<= 8)
+const TO_NANOSECONDS: jiff::Timestamp = jiff::Timestamp::constant(9223372036, 854775807); // DateTime64(9)
 
 macro_rules! impl_timestamp64 {
     ($precision:literal, $ser_conv:ident, $de_conv:ident) => {
+        impl_timestamp64!($precision, $ser_conv, $de_conv, upper_range = TO, try_from_error = Timestamp64OutOfRange);
+    };
+    (
+        $precision:literal,
+        $ser_conv:ident,
+        $de_conv:ident,
+        upper_range = $upper_range:ident,
+        try_from_error = $try_from_error:ident
+    ) => {
         impl Timestamp64<$precision> {
             #[doc = concat!("Convert `Timestamp64<", stringify!($precision), ">` to the underlying type.")]
             #[inline]
@@ -45,12 +66,12 @@ macro_rules! impl_timestamp64 {
         }
 
         impl TryFrom<jiff::Timestamp> for Timestamp64<$precision> {
-            type Error = Timestamp64OutOfRange;
+            type Error = $try_from_error;
             fn try_from(value: jiff::Timestamp) -> Result<Self, Self::Error> {
-                if value >= FROM && value <= TO {
+                if value >= FROM && value <= $upper_range {
                     Ok(Self(value))
                 } else {
-                    Err(Timestamp64OutOfRange)
+                    Err($try_from_error)
                 }
             }
         }
@@ -109,4 +130,10 @@ macro_rules! impl_timestamp64 {
 impl_timestamp64!(0, as_second, from_second);
 impl_timestamp64!(3, as_millisecond, from_millisecond);
 impl_timestamp64!(6, as_microsecond, from_microsecond);
-impl_timestamp64!(9, as_nanosecond, from_nanosecond);
+impl_timestamp64!(
+    9,
+    as_nanosecond,
+    from_nanosecond,
+    upper_range = TO_NANOSECONDS,
+    try_from_error = Timestamp64NanosecondsOutOfRange
+);

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -8,10 +8,10 @@ use serde_core::{
 /// that corresponds to `DateTime64` in ClickHouse.
 ///
 /// Supported precision:
-/// * Timestamp64<0> - seconds;
-/// * Timestamp64<3> - milliseconds;
-/// * Timestamp64<6> - microseconds;
-/// * Timestamp64<9> - nanoseconds.
+/// * `Timestamp64<0>` - seconds;
+/// * `Timestamp64<3>` - milliseconds;
+/// * `Timestamp64<6>` - microseconds;
+/// * `Timestamp64<9>` - nanoseconds.
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct Timestamp64<const PRECISION: u8>(jiff::Timestamp);

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -36,6 +36,14 @@ const TO: jiff::Timestamp = jiff::Timestamp::constant(9223372036, 854775807);
 
 macro_rules! impl_timestamp64 {
     ($precision:literal, $ser_conv:ident, $de_conv:ident) => {
+        impl Timestamp64<$precision> {
+            #[doc = concat!("Convert `Timestamp64<", stringify!($precision), ">` to the underlying type.")]
+            #[inline]
+            pub fn into_inner(self) -> jiff::Timestamp {
+                self.0
+            }
+        }
+
         impl TryFrom<jiff::Timestamp> for Timestamp64<$precision> {
             type Error = Timestamp64OutOfRange;
             fn try_from(value: jiff::Timestamp) -> Result<Self, Self::Error> {

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -1,0 +1,104 @@
+use core::{error, fmt};
+use serde_core::{
+    de::{Deserialize, Visitor},
+    ser::{Serialize, Serializer},
+};
+
+/// A wrapper type for [`jiff::Timestamp`]
+/// that corresponds to `DateTime64` in ClickHouse.
+///
+/// Supported precision:
+/// * Timestamp64<0> - seconds;
+/// * Timestamp64<3> - milliseconds;
+/// * Timestamp64<6> - microseconds;
+/// * Timestamp64<9> - nanoseconds.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, PartialOrd, Ord)]
+#[repr(transparent)]
+pub struct Timestamp64<const PRECISION: u8>(jiff::Timestamp);
+
+/// An error that occurs when [`jiff::Timestamp`]
+/// cannot be represented as a `DateTime64` in ClickHouse.
+#[derive(Debug)]
+pub struct Timestamp64OutOfRange;
+
+impl fmt::Display for Timestamp64OutOfRange {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        // f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2229-12-31 23:59:59.99999999].") // DateTime64(8)
+        f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2262-04-11 23:47:16.854775807].")
+    }
+}
+
+impl error::Error for Timestamp64OutOfRange {}
+
+const FROM: jiff::Timestamp = jiff::Timestamp::constant(-2208988800, 0);
+// const TO: jiff::Timestamp = jiff::Timestamp::constant(10413791999, 999999990); // DateTime64(8)
+const TO: jiff::Timestamp = jiff::Timestamp::constant(9223372036, 854775807);
+
+macro_rules! impl_timestamp64 {
+    ($precision:literal, $ser_conv:ident, $de_conv:ident) => {
+        impl TryFrom<jiff::Timestamp> for Timestamp64<$precision> {
+            type Error = Timestamp64OutOfRange;
+            fn try_from(value: jiff::Timestamp) -> Result<Self, Self::Error> {
+                if value >= FROM && value <= TO {
+                    Ok(Self(value))
+                } else {
+                    Err(Timestamp64OutOfRange)
+                }
+            }
+        }
+
+        impl From<Timestamp64<$precision>> for jiff::Timestamp {
+            #[inline]
+            fn from(value: Timestamp64<$precision>) -> Self {
+                value.0
+            }
+        }
+
+        impl Serialize for Timestamp64<$precision> {
+            fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+            where
+                S: Serializer,
+            {
+                // `TO` is defined as `from_nanosecond(i64::MAX as i128)`.
+                //
+                // Therefore, it's perfectly fine to cast `as_nanosecond`
+                // to i64.
+                let ts = self.0.$ser_conv() as i64;
+                ts.serialize(serializer)
+            }
+        }
+
+        impl<'de> Deserialize<'de> for Timestamp64<$precision> {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: serde_core::Deserializer<'de>,
+            {
+                struct TsVisitor;
+
+                impl<'de> Visitor<'de> for TsVisitor {
+                    type Value = Timestamp64<$precision>;
+
+                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                        formatter.write_str("an i64 representation of a ClickHouse DateTime64")
+                    }
+
+                    fn visit_i64<E>(self, v: i64) -> Result<Self::Value, E>
+                    where
+                        E: serde_core::de::Error,
+                    {
+                        let ts = jiff::Timestamp::$de_conv(v.into())
+                            .map_err(|_| E::custom("Failed to create a jiff::Timestamp"))?;
+                        Ok(Timestamp64::<$precision>(ts))
+                    }
+                }
+
+                deserializer.deserialize_i64(TsVisitor)
+            }
+        }
+    };
+}
+
+impl_timestamp64!(0, as_second, from_second);
+impl_timestamp64!(3, as_millisecond, from_millisecond);
+impl_timestamp64!(6, as_microsecond, from_microsecond);
+impl_timestamp64!(9, as_nanosecond, from_nanosecond);

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -22,7 +22,7 @@ pub struct Timestamp64<const PRECISION: u8>(jiff::Timestamp);
 pub struct Timestamp64OutOfRange;
 
 impl fmt::Display for Timestamp64OutOfRange {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         // f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2229-12-31 23:59:59.99999999].") // DateTime64(8)
         f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2262-04-11 23:47:16.854775807].")
     }
@@ -78,7 +78,7 @@ macro_rules! impl_timestamp64 {
                 impl<'de> Visitor<'de> for TsVisitor {
                     type Value = Timestamp64<$precision>;
 
-                    fn expecting(&self, formatter: &mut std::fmt::Formatter) -> fmt::Result {
+                    fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
                         formatter.write_str("an i64 representation of a ClickHouse DateTime64")
                     }
 

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -23,7 +23,7 @@ pub struct Timestamp64OutOfRange;
 
 impl fmt::Display for Timestamp64OutOfRange {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2229-12-31 23:59:59.99999999].") // DateTime64(8)
+        // f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2299-12-31 23:59:59.99999999].") // DateTime64(8)
         f.write_str("Timestamp is out of range, valid values are [1900-01-01 00:00:00, 2262-04-11 23:47:16.854775807].")
     }
 }

--- a/clickhouse-jiff/src/wrappers/timestamp64.rs
+++ b/clickhouse-jiff/src/wrappers/timestamp64.rs
@@ -1,6 +1,6 @@
 use core::{error, fmt};
 use serde_core::{
-    de::{Deserialize, Visitor},
+    de::{Deserialize, Deserializer, Visitor},
     ser::{Serialize, Serializer},
 };
 
@@ -100,7 +100,7 @@ macro_rules! impl_timestamp64 {
         impl<'de> Deserialize<'de> for Timestamp64<$precision> {
             fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
             where
-                D: serde_core::Deserializer<'de>,
+                D: Deserializer<'de>,
             {
                 struct TsVisitor;
 

--- a/tests/it/jiff.rs
+++ b/tests/it/jiff.rs
@@ -1,0 +1,541 @@
+use core::ops::RangeBounds;
+
+use clickhouse_jiff::{
+    Date16, Date32, SignedDuration32, SignedDuration64, Timestamp32, Timestamp64,
+};
+use jiff::{
+    SignedDuration,
+    civil::{Date, DateTime, Time},
+    tz::TimeZone,
+};
+use rand::{
+    Rng,
+    distr::{Distribution, StandardUniform},
+};
+use serde::{Deserialize, Serialize};
+
+use clickhouse::Row;
+
+#[tokio::test]
+async fn datetime() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
+    struct MyRow {
+        dt: Timestamp32,
+        dt_opt: Option<Timestamp32>,
+        dt64s: Timestamp64<0>,
+        dt64s_opt: Option<Timestamp64<0>>,
+        dt64ms: Timestamp64<3>,
+        dt64ms_opt: Option<Timestamp64<3>>,
+        dt64us: Timestamp64<6>,
+        dt64us_opt: Option<Timestamp64<6>>,
+        dt64ns: Timestamp64<9>,
+        dt64ns_opt: Option<Timestamp64<9>>,
+    }
+
+    #[derive(Debug, Deserialize, Row)]
+    struct MyRowStr {
+        dt: String,
+        dt64s: String,
+        dt64ms: String,
+        dt64us: String,
+        dt64ns: String,
+    }
+
+    client
+        .query(
+            "
+            CREATE TABLE test(
+                dt          DateTime,
+                dt_opt      Nullable(DateTime),
+                dt64s       DateTime64(0),
+                dt64s_opt   Nullable(DateTime64(0)),
+                dt64ms      DateTime64(3),
+                dt64ms_opt  Nullable(DateTime64(3)),
+                dt64us      DateTime64(6),
+                dt64us_opt  Nullable(DateTime64(6)),
+                dt64ns      DateTime64(9),
+                dt64ns_opt  Nullable(DateTime64(9))
+            )
+            ENGINE = MergeTree ORDER BY dt
+        ",
+        )
+        .execute()
+        .await
+        .unwrap();
+    let d = DateTime::constant(2022, 11, 13, 0, 0, 0, 0)
+        .to_zoned(TimeZone::UTC)
+        .unwrap();
+    let dt_s = d.with().hour(15).minute(27).second(42).build().unwrap();
+    let dt_ms = dt_s.with().millisecond(123).build().unwrap();
+    let dt_us = dt_ms.with().microsecond(456).build().unwrap();
+    let dt_ns = dt_us.with().nanosecond(789).build().unwrap();
+
+    let dt = Timestamp32::try_from(dt_s.timestamp()).unwrap();
+    let dt64s = Timestamp64::<_>::try_from(dt_s.timestamp()).unwrap();
+    let dt64ms = Timestamp64::<_>::try_from(dt_ms.timestamp()).unwrap();
+    let dt64us = Timestamp64::<_>::try_from(dt_us.timestamp()).unwrap();
+    let dt64ns = Timestamp64::<_>::try_from(dt_ns.timestamp()).unwrap();
+
+    let original_row = MyRow {
+        dt,
+        dt_opt: Some(dt),
+        dt64s,
+        dt64s_opt: Some(dt64s),
+        dt64ms,
+        dt64ms_opt: Some(dt64ms),
+        dt64us,
+        dt64us_opt: Some(dt64us),
+        dt64ns,
+        dt64ns_opt: Some(dt64ns),
+    };
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+    insert.write(&original_row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let row = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+
+    let row_str = client
+        .query(
+            "
+            SELECT toString(dt)     AS dt,
+                   toString(dt64s)  AS dt64s,
+                   toString(dt64ms) AS dt64ms,
+                   toString(dt64us) AS dt64us,
+                   toString(dt64ns) AS dt64ns
+              FROM test
+        ",
+        )
+        .fetch_one::<MyRowStr>()
+        .await
+        .unwrap();
+
+    assert_eq!(row, original_row);
+    assert_eq!(
+        row_str.dt,
+        original_row.dt.into_inner().strftime("%F %T").to_string()
+    );
+    assert_eq!(
+        row_str.dt64s,
+        original_row
+            .dt64s
+            .into_inner()
+            .strftime("%F %T")
+            .to_string()
+    );
+    assert_eq!(
+        row_str.dt64ms,
+        original_row
+            .dt64ms
+            .into_inner()
+            .strftime("%F %T%.f")
+            .to_string()
+    );
+    assert_eq!(
+        row_str.dt64us,
+        original_row
+            .dt64us
+            .into_inner()
+            .strftime("%F %T%.f")
+            .to_string()
+    );
+    assert_eq!(
+        row_str.dt64ns,
+        original_row
+            .dt64ns
+            .into_inner()
+            .strftime("%F %T%.f")
+            .to_string()
+    );
+}
+
+#[tokio::test]
+async fn date() {
+    let client = prepare_database!();
+
+    #[derive(Debug, Serialize, Deserialize, Row)]
+    struct MyRow {
+        date: Date16,
+        date_opt: Option<Date16>,
+    }
+
+    client
+        .query(
+            "
+            CREATE TABLE test(
+                date        Date,
+                date_opt    Nullable(Date)
+            ) ENGINE = MergeTree ORDER BY date
+        ",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+
+    let dates = generate_dates(1970..2149, 100);
+    for &date in &dates {
+        let date = Date16::try_from(date).unwrap();
+        let original_row = MyRow {
+            date,
+            date_opt: Some(date),
+        };
+
+        insert.write(&original_row).await.unwrap();
+    }
+    insert.end().await.unwrap();
+
+    let actual = client
+        .query("SELECT ?fields, toString(date) FROM test ORDER BY date")
+        .fetch_all::<(MyRow, String)>()
+        .await
+        .unwrap();
+
+    assert_eq!(actual.len(), dates.len());
+
+    for ((row, date_str), expected) in actual.iter().zip(dates) {
+        assert_eq!(row.date.into_inner(), expected);
+        assert_eq!(row.date_opt.map(|d| d.into_inner()), Some(expected));
+        assert_eq!(date_str, &expected.to_string());
+    }
+}
+
+#[tokio::test]
+async fn date32() {
+    let client = prepare_database!();
+
+    #[derive(Debug, Serialize, Deserialize, Row)]
+    struct MyRow {
+        date: Date32,
+        date_opt: Option<Date32>,
+    }
+
+    client
+        .query(
+            "
+            CREATE TABLE test(
+                date        Date32,
+                date_opt    Nullable(Date32)
+            ) ENGINE = MergeTree ORDER BY date
+        ",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+
+    let dates = generate_dates(1925..2283, 100); // TODO: 1900..=2299 for newer versions.
+    for &date in &dates {
+        let date = Date32::try_from(date).unwrap();
+        let original_row = MyRow {
+            date,
+            date_opt: Some(date),
+        };
+
+        insert.write(&original_row).await.unwrap();
+    }
+    insert.end().await.unwrap();
+
+    let actual = client
+        .query("SELECT ?fields, toString(date) FROM test ORDER BY date")
+        .fetch_all::<(MyRow, String)>()
+        .await
+        .unwrap();
+
+    assert_eq!(actual.len(), dates.len());
+
+    for ((row, date_str), expected) in actual.iter().zip(dates) {
+        assert_eq!(row.date.into_inner(), expected);
+        assert_eq!(row.date_opt.map(|d| d.into_inner()), Some(expected));
+        assert_eq!(date_str, &expected.to_string());
+    }
+}
+
+// Distribution isn't implemented for `jiff` types,
+// let's implement it ourselves.
+struct DateWrapper(Date);
+
+impl Distribution<DateWrapper> for StandardUniform {
+    fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> DateWrapper {
+        // For some reason adding to a Date a SignedDuration that is larger than
+        // 2932896 days causes an overflow.
+        //
+        // Causing this:
+        // ```
+        // Date::MIN + Date::MAX.duration_since(Date::MIN)
+        // ```
+        // to fail.
+        //
+        // Let's just limit ourselves to years 1900 - 2299 (roughly 3506304 hours).
+        DateWrapper(
+            Date::constant(1900, 1, 1) + SignedDuration::from_hours(rng.random_range(0..=3506304)),
+        )
+    }
+}
+
+fn generate_dates(years: impl RangeBounds<i16>, count: usize) -> Vec<Date> {
+    let mut rng = rand::rng();
+    let mut dates: Vec<_> = (&mut rng)
+        .sample_iter(StandardUniform)
+        .filter_map(|date: DateWrapper| {
+            if years.contains(&date.0.year()) {
+                Some(date.0)
+            } else {
+                None
+            }
+        })
+        .take(count)
+        .collect();
+
+    dates.sort_unstable();
+    dates
+}
+
+#[tokio::test]
+async fn time_roundtrip() {
+    let client = prepare_database!();
+
+    client
+        .query(
+            r#"
+            CREATE TABLE test(
+                t0  Time,
+                t1  Nullable(Time)
+            ) ENGINE = MergeTree ORDER BY tuple()
+            SETTINGS enable_time_time64_type = 1;
+            "#,
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
+    struct TimeRow {
+        t0: SignedDuration32,
+        t1: Option<SignedDuration32>,
+    }
+
+    let time = Time::constant(12, 34, 56, 0);
+    let duration = SignedDuration32::try_from(time.duration_since(Time::midnight())).unwrap();
+
+    let row = TimeRow {
+        t0: duration,
+        t1: Some(duration),
+    };
+
+    let mut insert = client.insert::<TimeRow>("test").await.unwrap();
+    insert.write(&row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let fetched = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<TimeRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(fetched, row);
+}
+
+#[tokio::test]
+async fn time_negative_roundtrip() {
+    let client = prepare_database!();
+
+    client
+        .query(
+            r#"
+            CREATE TABLE test(
+                t0  Time,
+                t1  Nullable(Time)
+            ) ENGINE = MergeTree ORDER BY tuple()
+            SETTINGS enable_time_time64_type = 1;
+            "#,
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
+    struct TimeRow {
+        t0: SignedDuration32,
+        t1: Option<SignedDuration32>,
+    }
+
+    // Create negative duration directly
+    let negative_duration =
+        SignedDuration32::try_from(SignedDuration::from_secs(-2 * 3600 - 15 * 60 - 30)).unwrap(); // -02:15:30
+
+    let row = TimeRow {
+        t0: negative_duration,
+        t1: Some(negative_duration),
+    };
+
+    let mut insert = client.insert::<TimeRow>("test").await.unwrap();
+    insert.write(&row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let fetched = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<TimeRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(fetched, row);
+}
+
+#[tokio::test]
+async fn time64_roundtrip() {
+    let client = prepare_database!();
+
+    client
+        .query(
+            r#"
+            CREATE TABLE test(
+                t0      Time64(0),
+                t0_opt  Nullable(Time64(0)),
+                t3      Time64(3),
+                t3_opt  Nullable(Time64(3)),
+                t6      Time64(6),
+                t6_opt  Nullable(Time64(6)),
+                t9      Time64(9),
+                t9_opt  Nullable(Time64(9))
+            ) ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS enable_time_time64_type = 1;
+            "#,
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
+    struct MyRow {
+        t0: SignedDuration64<0>,
+        t0_opt: Option<SignedDuration64<0>>,
+
+        t3: SignedDuration64<3>,
+        t3_opt: Option<SignedDuration64<3>>,
+
+        t6: SignedDuration64<6>,
+        t6_opt: Option<SignedDuration64<6>>,
+
+        t9: SignedDuration64<9>,
+        t9_opt: Option<SignedDuration64<9>>,
+    }
+
+    let time_s = Time::constant(12, 34, 56, 0);
+    let time_ms = Time::constant(12, 34, 56, 789_000_000);
+    let time_us = Time::constant(12, 34, 56, 789_123_000);
+    let time_ns = Time::constant(12, 34, 56, 789_123_456);
+
+    let dur_s = SignedDuration64::<_>::try_from(time_s.duration_since(Time::midnight())).unwrap();
+    let dur_ms = SignedDuration64::<_>::try_from(time_ms.duration_since(Time::midnight())).unwrap();
+    let dur_us = SignedDuration64::<_>::try_from(time_us.duration_since(Time::midnight())).unwrap();
+    let dur_ns = SignedDuration64::<_>::try_from(time_ns.duration_since(Time::midnight())).unwrap();
+
+    let original_row = MyRow {
+        t0: dur_s,
+        t0_opt: Some(dur_s),
+        t3: dur_ms,
+        t3_opt: Some(dur_ms),
+        t6: dur_us,
+        t6_opt: Some(dur_us),
+        t9: dur_ns,
+        t9_opt: Some(dur_ns),
+    };
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+    insert.write(&original_row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let fetched = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(fetched, original_row);
+}
+
+#[tokio::test]
+async fn time64_negative_roundtrip() {
+    let client = prepare_database!();
+
+    client
+        .query(
+            r#"
+            CREATE TABLE test(
+                t0      Time64(0),
+                t0_opt  Nullable(Time64(0)),
+                t3      Time64(3),
+                t3_opt  Nullable(Time64(3)),
+                t6      Time64(6),
+                t6_opt  Nullable(Time64(6)),
+                t9      Time64(9),
+                t9_opt  Nullable(Time64(9))
+            ) ENGINE = MergeTree
+            ORDER BY tuple()
+            SETTINGS enable_time_time64_type = 1;
+            "#,
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    #[derive(Debug, PartialEq, Serialize, Deserialize, Row)]
+    struct MyRow {
+        t0: SignedDuration64<0>,
+        t0_opt: Option<SignedDuration64<0>>,
+
+        t3: SignedDuration64<3>,
+        t3_opt: Option<SignedDuration64<3>>,
+
+        t6: SignedDuration64<6>,
+        t6_opt: Option<SignedDuration64<6>>,
+
+        t9: SignedDuration64<9>,
+        t9_opt: Option<SignedDuration64<9>>,
+    }
+
+    // Create negative durations directly
+    let neg_base_seconds = -5 * 3600 - 15 * 60 - 30; // -18930 seconds (-05:15:30)
+
+    let dur_s = SignedDuration::from_secs(neg_base_seconds);
+    let dur_ms = SignedDuration64::<_>::try_from(dur_s - SignedDuration::from_millis(123)).unwrap();
+    let dur_us =
+        SignedDuration64::<_>::try_from(dur_s - SignedDuration::from_micros(123_456)).unwrap();
+    let dur_ns =
+        SignedDuration64::<_>::try_from(dur_s - SignedDuration::from_nanos(123_456_789)).unwrap();
+
+    let dur_s = SignedDuration64::<_>::try_from(dur_s).unwrap();
+
+    let negative_row = MyRow {
+        t0: dur_s,
+        t0_opt: Some(dur_s),
+        t3: dur_ms,
+        t3_opt: Some(dur_ms),
+        t6: dur_us,
+        t6_opt: Some(dur_us),
+        t9: dur_ns,
+        t9_opt: Some(dur_ns),
+    };
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+    insert.write(&negative_row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let fetched = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(fetched, negative_row);
+}

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -261,6 +261,7 @@ mod inserter;
 mod int128;
 mod int256;
 mod ip;
+mod jiff;
 mod mock;
 mod nested;
 #[cfg(feature = "opentelemetry")]


### PR DESCRIPTION
## Summary
Implement support for [jiff](https://docs.rs/jiff/latest/jiff/).

It's a somewhat new datetime library, inspired by [JavaScript's Temporal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Temporal). Unlike `chrono` and `time`, it supports [TZif files](https://datatracker.ietf.org/doc/html/rfc8536) out of the box, which is why I prefer it to the other two.

The PR is heavily based on the `chrono` implementation.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [x] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
