### PR TITLE
ci: add publish action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,7 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions: write-all
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Dry run (do not publish to crates.io)'
+        required: true
+        default: 'true'
+      level:
+        description: 'Release level'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+  RUSTDOCFLAGS: -Dwarnings
+  RUST_BACKTRACE: 1
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - run: rustup show active-toolchain -v
+
+      - name: Install cargo-release
+        run: cargo install cargo-release
+
+      - name: Release
+        run: |
+          cargo release ${{ github.event.inputs.level }} ${{
+            if eq(github.event.inputs.dry-run, 'false') 
+            then '--execute' 
+            else '' 
+            end
+          }}


### PR DESCRIPTION
Closes #297 
We can try this when 0.14.0 is ready, cause crates support setting ClickHouse/clickhouse-rs as a trusted publisher.