### PR TITLE
chore: address remaining feedback of #244 (feat!(insert): `RowBinaryWithNamesAndTypes`)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
       - run: rustup override set nightly
       - run: rustup show active-toolchain -v
       # Serde 1.0.227 fails to build with `--cfg docsrs`, only pass it to our own packages
-      - run: cargo rustdoc -p clickhouse-derive -- -D warnings --cfg docsrs
-      - run: cargo rustdoc -p clickhouse-types -- -D warnings --cfg docsrs
-      - run: cargo rustdoc -p clickhouse -- -D warnings --cfg docsrs
+      - run: cargo rustdoc -p clickhouse-derive --all-features -- -D warnings --cfg docsrs
+      - run: cargo rustdoc -p clickhouse-types --all-features -- -D warnings --cfg docsrs
+      - run: cargo rustdoc -p clickhouse --all-features -- -D warnings --cfg docsrs
 
   test:
     runs-on: ubuntu-latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,8 @@
 name: clickhouse-rs
 services:
   clickhouse:
-    image: 'clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-latest-alpine}'
+    # Note: use of a fully qualified url makes Podman happy without need for further configuration.
+    image: 'docker.io/clickhouse/clickhouse-server:${CLICKHOUSE_VERSION-latest-alpine}'
     container_name: 'clickhouse-rs-clickhouse-server'
     environment:
       CLICKHOUSE_SKIP_USER_SETUP: 1

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -12,7 +12,6 @@ use bytes::{Bytes, BytesMut};
 use clickhouse_types::put_rbwnat_columns_header;
 use hyper::{self, Request};
 use replace_with::replace_with_or_abort;
-use std::sync::Arc;
 use std::{future::Future, marker::PhantomData, mem, panic, pin::Pin, time::Duration};
 use tokio::{
     task::JoinHandle,
@@ -48,7 +47,7 @@ const_assert!(BUFFER_SIZE.is_power_of_two()); // to use the whole buffer's capac
 pub struct Insert<T> {
     state: InsertState,
     buffer: BytesMut,
-    row_metadata: Option<Arc<RowMetadata>>,
+    row_metadata: Option<RowMetadata>,
     #[cfg(feature = "lz4")]
     compression: Compression,
     send_timeout: Option<Duration>,
@@ -131,7 +130,7 @@ macro_rules! timeout {
 }
 
 impl<T> Insert<T> {
-    pub(crate) fn new(client: &Client, table: &str, row_metadata: Option<Arc<RowMetadata>>) -> Self
+    pub(crate) fn new(client: &Client, table: &str, row_metadata: Option<RowMetadata>) -> Self
     where
         T: Row,
     {

--- a/src/insert.rs
+++ b/src/insert.rs
@@ -34,6 +34,16 @@ const_assert!(BUFFER_SIZE.is_power_of_two()); // to use the whole buffer's capac
 /// Otherwise, the whole `INSERT` will be aborted.
 ///
 /// Rows are being sent progressively to spread network load.
+///
+/// # Note: Metadata is Cached
+/// If [validation is enabled][Client::with_validation],
+/// this helper will query the metadata for the target table to learn the column names and types.
+///
+/// To avoid querying this metadata every time, it is cached within the [`Client`].
+///
+/// Any concurrent changes to the table schema may cause insert failures if the metadata
+/// is no longer correct. For correct functioning, call [`Client::clear_cached_metadata()`]
+/// after any changes to the current database schema.
 #[must_use]
 pub struct Insert<T> {
     state: InsertState,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,6 +145,8 @@ impl Client {
 
     /// Specifies a database name.
     ///
+    ///
+    ///
     /// # Examples
     /// ```
     /// # use clickhouse::Client;
@@ -153,7 +155,7 @@ impl Client {
     pub fn with_database(mut self, database: impl Into<String>) -> Self {
         self.database = Some(database.into());
 
-        // If we're looking at a different database, then our cached metadata is invalid.
+        // Assume our cached metadata is invalid.
         self.row_metadata_cache = Default::default();
 
         self
@@ -392,9 +394,12 @@ impl Client {
     /// If the table schema changes, this metadata needs to re-fetched.
     ///
     /// This method clears the metadata cache, causing future insert queries to re-fetch metadata.
+    /// This applies to all cloned instances of this `Client` as well.
     ///
     /// This may need to wait to acquire a lock if a query is concurrently writing into the cache.
-    pub async fn clear_cached_metadata(&mut self) {
+    ///
+    /// Cancel-safe.
+    pub async fn clear_cached_metadata(&self) {
         self.row_metadata_cache.0.write().await.clear();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -403,6 +403,15 @@ impl Client {
     /// in your specific use case. Additionally, writing smoke tests to ensure that
     /// the row types match the ClickHouse schema is highly recommended,
     /// if you plan to disable validation in your application.
+    ///
+    /// # Note: Mocking
+    /// When using [`test::Mock`] with the `test-util` feature, validation is forced off.
+    ///
+    /// This applies either when using [`Client::with_mock()`], or [`Client::with_url()`]
+    /// with a URL from [`test::Mock::url()`].
+    ///
+    /// As of writing, the mocking facilities are unable to generate the `RowBinaryWithNamesAndTypes`
+    /// header required for validation to function.
     pub fn with_validation(mut self, enabled: bool) -> Self {
         self.validation = enabled;
         self

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,7 +16,6 @@ use crate::sql::Identifier;
 pub use clickhouse_derive::Row;
 use clickhouse_types::parse_rbwnat_columns_header;
 
-use std::time::Duration;
 use std::{collections::HashMap, fmt::Display, sync::Arc};
 use tokio::sync::RwLock;
 
@@ -63,7 +62,7 @@ pub struct Client {
     products_info: Vec<ProductInfo>,
     validation: bool,
     row_metadata_cache: Arc<RowMetadataCache>,
-    metadata_ttl: Option<Duration>,
+
     #[cfg(feature = "test-util")]
     mocked: bool,
 }
@@ -127,7 +126,6 @@ impl Client {
             products_info: Vec::default(),
             validation: true,
             row_metadata_cache: Arc::new(RowMetadataCache::default()),
-            metadata_ttl: Some(Duration::from_secs(60 * 60)), // 1 hour
             #[cfg(feature = "test-util")]
             mocked: false,
         }
@@ -328,17 +326,6 @@ impl Client {
         self
     }
 
-    /// Set or clear the time-to-live for cached metadata.
-    ///
-    /// Any metadata older than this will be re-fetched.
-    ///
-    /// Set to `None` to cache metadata forever. The cache can still be manually cleared with
-    /// [`Client::clear_cached_metadata()`].
-    pub fn with_metadata_ttl(mut self, ttl: impl Into<Option<Duration>>) -> Self {
-        self.metadata_ttl = ttl.into();
-        self
-    }
-
     /// Starts a new INSERT statement.
     ///
     /// # Validation
@@ -450,13 +437,7 @@ impl Client {
             let read_lock = self.row_metadata_cache.0.read().await;
 
             if let Some(metadata) = read_lock.get(table_name) {
-                // FIXME: `Option::is_none_or` isn't available until 1.82
-                if self
-                    .metadata_ttl
-                    .map_or(true, |ttl| metadata.received_at.elapsed() < ttl)
-                {
-                    return Ok(metadata.clone());
-                }
+                return Ok(metadata.clone());
             }
         }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,14 @@ impl Client {
     pub fn with_url(mut self, url: impl Into<String>) -> Self {
         self.url = url.into();
 
+        // `with_mock()` didn't exist previously, so to not break existing usages,
+        // we need to be able to detect a mocked server using nothing but the URL.
+        #[cfg(feature = "test-util")]
+        if let Some(url) = test::Mock::mocked_url_to_real(&self.url) {
+            self.url = url;
+            self.mocked = true;
+        }
+
         // Assume our cached metadata is invalid.
         self.insert_metadata_cache = Default::default();
 
@@ -442,7 +450,7 @@ impl Client {
     /// which is pointless in that kind of tests.
     #[cfg(feature = "test-util")]
     pub fn with_mock(mut self, mock: &test::Mock) -> Self {
-        self.url = mock.url().to_string();
+        self.url = mock.real_url().to_string();
         self.mocked = true;
         self
     }

--- a/src/row_metadata.rs
+++ b/src/row_metadata.rs
@@ -3,7 +3,6 @@ use crate::row::RowKind;
 use clickhouse_types::Column;
 use std::collections::HashMap;
 use std::fmt::Display;
-use std::time::Instant;
 
 #[derive(Debug, PartialEq)]
 pub(crate) enum AccessType {
@@ -23,7 +22,6 @@ pub(crate) struct RowMetadata {
     /// * For selects, it is defined in the same order as in the database schema.
     /// * For inserts, it is adjusted to the order of fields in the struct definition.
     pub(crate) columns: Vec<Column>,
-
     /// This determines whether we can just use [`crate::rowbinary::de::RowBinarySeqAccess`]
     /// or a more sophisticated approach with [`crate::rowbinary::de::RowBinaryStructAsMapAccess`]
     /// to support structs defined with different fields order than in the schema.
@@ -32,9 +30,6 @@ pub(crate) struct RowMetadata {
     /// on the shape of the data. In some cases, there is no noticeable difference,
     /// in others, it could be up to 2-3x slower.
     pub(crate) access_type: AccessType,
-
-    /// The time this row metadata was received. Used for enforcing the TTL when cached.
-    pub(crate) received_at: Instant,
 }
 
 impl RowMetadata {
@@ -123,7 +118,6 @@ impl RowMetadata {
         Self {
             columns,
             access_type,
-            received_at: Instant::now(),
         }
     }
 
@@ -172,7 +166,6 @@ impl RowMetadata {
         Self {
             columns: result_columns,
             access_type: AccessType::WithSeqAccess, // ignored
-            received_at: Instant::now(),
         }
     }
 

--- a/src/rowbinary/de.rs
+++ b/src/rowbinary/de.rs
@@ -213,7 +213,7 @@ where
 
     /// This is used to deserialize identifiers for either:
     /// - `Variant` data type
-    /// - [`RowBinaryStructAsMapAccess`] field.
+    /// - out-of-order struct fields using [`MapAccess`].
     #[inline(always)]
     fn deserialize_identifier<V: Visitor<'data>>(self, visitor: V) -> Result<V::Value> {
         ensure_size(&mut self.input, size_of::<u8>())?;

--- a/src/test/mock.rs
+++ b/src/test/mock.rs
@@ -15,9 +15,22 @@ use tokio::{net::TcpListener, task::AbortHandle};
 
 use super::{Handler, HandlerFn};
 
+/// URL using a special hostname that `Client` can use to detect a mocked server.
+///
+/// This is to avoid breaking existing usages of the mock API which just call
+/// `client.with_url(mock.url)`.
+///
+/// This domain should not resolve otherwise. The `.test` top-level domain
+/// is reserved and cannot be registered on the open Internet.
+const MOCKED_BASE_URL: &'static str = "http://mocked.clickhouse.test";
+
+/// The real base URL where the mocked server is listening.
+const REAL_BASE_URL: &'static str = "http://127.0.0.1";
+
 /// A mock server for testing.
 pub struct Mock {
-    url: String,
+    mock_url: String,
+    pub(crate) real_url: String,
     shared: Arc<Mutex<Shared>>,
     non_exhaustive: bool,
     server_handle: AbortHandle,
@@ -51,7 +64,8 @@ impl Mock {
         let server_handle = tokio::spawn(server(listener, shared.clone()));
 
         Self {
-            url: format!("http://{addr}"),
+            mock_url: format!("{MOCKED_BASE_URL}:{}", addr.port()),
+            real_url: format!("{REAL_BASE_URL}:{}", addr.port()),
             non_exhaustive: false,
             server_handle: server_handle.abort_handle(),
             shared,
@@ -62,7 +76,18 @@ impl Mock {
     ///
     /// [`Client`]: crate::Client::with_url
     pub fn url(&self) -> &str {
-        &self.url
+        &self.mock_url
+    }
+
+    pub(crate) fn real_url(&self) -> &str {
+        &self.real_url
+    }
+
+    /// Returns `Some` if `url` was a mocked URL and converted to real, `None` if already real.
+    pub(crate) fn mocked_url_to_real(url: &str) -> Option<String> {
+        url.strip_prefix(MOCKED_BASE_URL)
+            // rest = ":{port}"
+            .map(|rest| format!("{REAL_BASE_URL}{rest}"))
     }
 
     /// Adds a handler to the test server for the next request.

--- a/src/test/mock.rs
+++ b/src/test/mock.rs
@@ -22,10 +22,10 @@ use super::{Handler, HandlerFn};
 ///
 /// This domain should not resolve otherwise. The `.test` top-level domain
 /// is reserved and cannot be registered on the open Internet.
-const MOCKED_BASE_URL: &'static str = "http://mocked.clickhouse.test";
+const MOCKED_BASE_URL: &str = "http://mocked.clickhouse.test";
 
 /// The real base URL where the mocked server is listening.
-const REAL_BASE_URL: &'static str = "http://127.0.0.1";
+const REAL_BASE_URL: &str = "http://127.0.0.1";
 
 /// A mock server for testing.
 pub struct Mock {

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -78,7 +78,7 @@ macro_rules! assert_panic_msg {
             result.unwrap()
         );
         let panic_msg = *result.unwrap_err().downcast::<String>().unwrap();
-        for &msg in $msg_parts {
+        for msg in $msg_parts {
             assert!(
                 panic_msg.contains(msg),
                 "panic message:\n{panic_msg}\ndid not contain the expected part:\n{msg}"

--- a/tests/it/mock.rs
+++ b/tests/it/mock.rs
@@ -25,3 +25,18 @@ async fn provide() {
     tokio::time::advance(Duration::from_secs(100_000)).await;
     test_provide().await;
 }
+
+#[tokio::test]
+async fn client_with_url() {
+    let mock = test::Mock::new();
+
+    // Existing usages before `with_mock()` was introduced should not silently break.
+    let client = Client::default().with_url(mock.url());
+    let expected = vec![SimpleRow::new(1, "one"), SimpleRow::new(2, "two")];
+
+    // FIXME: &expected is not allowed due to new trait bounds
+    mock.add(test::handlers::provide(expected.clone()));
+
+    let actual = crate::fetch_rows::<SimpleRow>(&client, "doesn't matter").await;
+    assert_eq!(actual, expected);
+}

--- a/tests/it/rbwnat_smoke.rs
+++ b/tests/it/rbwnat_smoke.rs
@@ -1490,15 +1490,6 @@ async fn ephemeral_columns() {
 }
 
 // See https://clickhouse.com/docs/sql-reference/statements/alter/column#materialize-column
-//
-// Ignored cause:
-//
-// While processing struct Data: database schema has 1 column(s), but the struct definition has 2 field(s).
-// #### All struct fields:
-// - x
-// - s
-// #### All schema columns:
-// - x: Int64
 #[tokio::test]
 async fn materialized_columns() {
     let table_name = "test_materialized_columns";

--- a/tests/it/rbwnat_validation.rs
+++ b/tests/it/rbwnat_validation.rs
@@ -531,7 +531,14 @@ async fn issue_109_1() {
     let unwind = std::panic::AssertUnwindSafe(async {
         let _ = client.insert::<Data>("issue_109").await.unwrap();
     });
-    assert_panic_msg!(unwind, &["Data", "4 columns", "3 fields"]);
+
+    assert_panic_msg!(
+        unwind,
+        &[
+            "the following non-default columns are missing",
+            "en_id: String"
+        ]
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
The intent of this PR is to address the remaining feedback on #244.

Fixes #295
Fixes #298
Fixes #299 

## Checklist

- [x] #295
  - [x] add `Client::clear_cached_metadata()`
  - [x] invalidate metadata in `Client::with_url()`, `Client::with_database()`
  - [x] ~add `Client::with_metadata_ttl()`~ (reverted)
  - [x] add test for metadata invalidation
- [x]  #298
  - [x] query `system.columns` for more metadata
  - [x] test
- [x]  #299
  - [x] ~support RWBNAT header in mocked data~ (punting because it requires design work/discussion)
  - [x] don't break existing usage of `Client::with_url()` with mocks
  - [x] doc: note that validation is forced off when mocking