### PR TITLE
fix(ci): only pass `--cfg docsrs` to our own packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   RUSTFLAGS: -Dwarnings
-  RUSTDOCFLAGS: -Dwarnings
   RUST_BACKTRACE: 1
   # note: MSRV now tracked in `rust-toolchain.toml`
 
@@ -54,14 +53,15 @@ jobs:
   docs:
     needs: build
     runs-on: ubuntu-latest
-    env:
-      RUSTDOCFLAGS: -Dwarnings --cfg docsrs
     steps:
       - uses: actions/checkout@v4
       - run: rustup toolchain install nightly
       - run: rustup override set nightly
       - run: rustup show active-toolchain -v
-      - run: cargo doc --all-features
+      # Serde 1.0.227 fails to build with `--cfg docsrs`, only pass it to our own packages
+      - run: cargo rustdoc -p clickhouse-derive -- -D warnings --cfg docsrs
+      - run: cargo rustdoc -p clickhouse-types -- -D warnings --cfg docsrs
+      - run: cargo rustdoc -p clickhouse -- -D warnings --cfg docsrs
 
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Serde 1.0.227 made significant changes to their build process for `docsrs` and building with `RUSTDOCFLAGS="-D warnings --cfg docsrs"` was causing CI to fail.

Instead, we can use `cargo rustdoc` to pass flags only to rustdoc invocations for our own crates (which more closely matches what docs.rs actually does: https://docs.rs/about/builds#detecting-docsrs).

## Checklist
Delete items not relevant to your PR:

- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
