### PR TITLE
fix: delete use of removed `doc_auto_cfg` feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,5 @@
 #![doc = include_str!("../README.md")]
 #![cfg_attr(docsrs, feature(doc_cfg))]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 #[macro_use]
 extern crate static_assertions;


### PR DESCRIPTION
## Summary
#304 should have fixed CI but it broke again on `main`. It looks like the `doc_auto_cfg` was only just deleted on nightly.
