### PR TITLE
chore: bump crates versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,7 +122,7 @@ rustls-tls-native-roots = [
 ]
 
 [dependencies]
-clickhouse-derive = { version = "0.2.0", path = "derive" }
+clickhouse-derive = { version = "0.3.0", path = "derive" }
 clickhouse-types = { version = "0.1.0", path = "types" }
 
 thiserror = "2.0"
@@ -155,7 +155,7 @@ quanta = { version = "0.12", optional = true }
 replace_with = { version = "0.1.7" }
 
 [dev-dependencies]
-clickhouse-derive = { version = "0.2.0", path = "derive" }
+clickhouse-derive = { version = "0.3.0", path = "derive" }
 criterion = "0.6"
 serde = { version = "1.0.106", features = ["derive"] }
 tokio = { version = "1.0.1", features = ["full", "test-util"] }

--- a/derive/Cargo.toml
+++ b/derive/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "clickhouse-derive"
 description = "A macro for deriving clickhouse::Row"
-version = "0.2.0"
+version = "0.3.0"
 
 authors.workspace = true
 repository.workspace = true


### PR DESCRIPTION
Bumps clickhouse-derive, as there were some breaking changes