### PR TITLE
Added support for Vec<UUID> // Array(UUID) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,21 @@ Usage of all mentioned data types are covered in the following examples:
     }
     ```
     </details>
+* `Array(UUID)` maps to/from `Vec<uuid::Uuid>` by using `serde::uuid_vec`. Requires the `uuid` feature.
+    <details>
+    <summary>Example</summary>
+
+    ```rust,no_run
+    use serde::{Serialize, Deserialize};
+    use clickhouse::Row;
+
+    #[derive(Row, Serialize, Deserialize)]
+    struct MyRow {
+        #[serde(with = "clickhouse::serde::uuid_vec")]
+        uuids: Vec<uuid::Uuid>,
+    }
+    ```
+    </details>
 * `IPv6` maps to/from [`std::net::Ipv6Addr`](https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html).
 * `IPv4` maps to/from [`std::net::Ipv4Addr`](https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html) by using `serde::ipv4`.
     <details>

--- a/README.md
+++ b/README.md
@@ -351,21 +351,6 @@ Usage of all mentioned data types are covered in the following examples:
     }
     ```
     </details>
-* `Array(UUID)` maps to/from `Vec<uuid::Uuid>` by using `serde::uuid_vec`. Requires the `uuid` feature.
-    <details>
-    <summary>Example</summary>
-
-    ```rust,no_run
-    use serde::{Serialize, Deserialize};
-    use clickhouse::Row;
-
-    #[derive(Row, Serialize, Deserialize)]
-    struct MyRow {
-        #[serde(with = "clickhouse::serde::uuid_vec")]
-        uuids: Vec<uuid::Uuid>,
-    }
-    ```
-    </details>
 * `IPv6` maps to/from [`std::net::Ipv6Addr`](https://doc.rust-lang.org/stable/std/net/struct.Ipv6Addr.html).
 * `IPv4` maps to/from [`std::net::Ipv4Addr`](https://doc.rust-lang.org/stable/std/net/struct.Ipv4Addr.html) by using `serde::ipv4`.
     <details>
@@ -525,7 +510,21 @@ Usage of all mentioned data types are covered in the following examples:
     ```
     </details>
 * `Tuple(A, B, ...)` maps to/from `(A, B, ...)` or a newtype around it.
-* `Array(_)` maps to/from any slice, e.g. `Vec<_>`, `&[_]`. Newtypes are also supported.
+* `Array(_)` maps to/from any slice, e.g. `Vec<_>`, `&[_]`, and `UUID` (using `serde::uuid_vec`). Newtypes are also supported. 
+    <details>
+    <summary>Example</summary>
+
+    ```rust,no_run
+    use serde::{Serialize, Deserialize};
+    use clickhouse::Row;
+
+    #[derive(Row, Serialize, Deserialize)]
+    struct MyRow {
+        #[serde(with = "clickhouse::serde::uuid_vec")]
+        uuids: Vec<uuid::Uuid>,
+    }
+    ```
+    </details>
 * `Map(K, V)` can be deserialized as `HashMap<K, V>` or `Vec<(K, V)>`.
 * `LowCardinality(_)` is supported seamlessly.
 * `Nullable(_)` maps to/from `Option<_>`. For `clickhouse::serde::*` helpers add `::option`.

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -105,7 +105,88 @@ pub mod uuid {
         }
     }
 }
+/// Ser/de `Vec<`[`::uuid::Uuid`]`>` to/from `Array(UUID)`.
+#[cfg(feature = "uuid")]
+pub mod uuid_vec {
+    use super::*;
+    use ::uuid::Uuid;
+    use serde::de::{Error, SeqAccess, Visitor};
+    use serde::ser::SerializeSeq;
+    use std::fmt;
 
+    pub mod option {
+        use super::*;
+        use ::uuid::Uuid;
+
+        pub fn serialize<S>(uuids: &Option<Vec<Uuid>>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            match uuids {
+                Some(uuids) => super::serialize(uuids, serializer),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<Uuid>>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            Option::<Vec<Uuid>>::deserialize(deserializer)
+        }
+    }
+
+    pub fn serialize<S>(uuids: &[Uuid], serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let human_readable = serializer.is_human_readable();
+        let mut seq = serializer.serialize_seq(Some(uuids.len()))?;
+        if human_readable {
+            for uuid in uuids {
+                seq.serialize_element(&uuid.to_string())?;
+            }
+        } else {
+            for uuid in uuids {
+                seq.serialize_element(&uuid.as_u64_pair())?;
+            }
+        }
+        seq.end()
+    }
+
+    struct UuidVecVisitor {
+        human_readable: bool,
+    }
+
+    impl<'de> Visitor<'de> for UuidVecVisitor {
+        type Value = Vec<Uuid>;
+
+        fn expecting(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "a sequence of UUID values")
+        }
+        fn visit_seq<A: SeqAccess<'de>>(self, mut seq: A) -> Result<Self::Value, A::Error> {
+            let mut uuids = Vec::with_capacity(seq.size_hint().unwrap_or(0));
+            if self.human_readable {
+                while let Some(s) = seq.next_element::<&str>()? {
+                    uuids.push(Uuid::parse_str(s).map_err(A::Error::custom)?);
+                }
+            } else {
+                while let Some((high, low)) = seq.next_element::<(u64, u64)>()? {
+                    uuids.push(Uuid::from_u64_pair(high, low));
+                }
+            }
+            Ok(uuids)
+        }
+    }
+
+    pub fn deserialize<'de, D>(deserializer: D) -> Result<Vec<Uuid>, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let human_readable = deserializer.is_human_readable();
+        deserializer.deserialize_seq(UuidVecVisitor { human_readable })
+    }
+}
 #[cfg(feature = "chrono")]
 pub mod chrono {
     use super::*;

--- a/tests/it/uuid.rs
+++ b/tests/it/uuid.rs
@@ -80,3 +80,68 @@ async fn human_readable_smoke() {
 
     assert_eq!(new_row2, row2);
 }
+#[tokio::test]
+async fn vec_smoke() {
+    let client = prepare_database!();
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
+    struct MyRow {
+        #[serde(with = "clickhouse::serde::uuid_vec")]
+        uuids: Vec<Uuid>,
+    }
+
+    client
+        .query(
+            "
+            CREATE TABLE test(
+                uuids Array(UUID)
+            ) ENGINE = MergeTree ORDER BY uuids
+        ",
+        )
+        .execute()
+        .await
+        .unwrap();
+
+    let uuids = vec![Uuid::new_v4(), Uuid::new_v4()];
+    println!("uuids: {uuids:?}");
+
+    let original_row = MyRow { uuids };
+
+    let mut insert = client.insert::<MyRow>("test").await.unwrap();
+    insert.write(&original_row).await.unwrap();
+    insert.end().await.unwrap();
+
+    let row = client
+        .query("SELECT ?fields FROM test")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+
+    assert_eq!(row, original_row);
+}
+#[tokio::test]
+async fn vec_human_readable_smoke() {
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
+    struct OursRow {
+        #[serde(with = "clickhouse::serde::uuid_vec")]
+        uuids: Vec<Uuid>,
+    }
+
+    #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
+    struct TheirsRow {
+        uuids: Vec<Uuid>,
+    }
+
+    let uuids = vec![Uuid::new_v4(), Uuid::new_v4()];
+    let row = OursRow {
+        uuids: uuids.clone(),
+    };
+    let row2 = TheirsRow { uuids };
+
+    let s1 = serde_json::to_string(&row).unwrap();
+    let s2 = serde_json::to_string(&row2).unwrap();
+    assert_eq!(s1, s2);
+
+    let new_row2: TheirsRow = serde_json::from_str(&s2).unwrap();
+    assert_eq!(new_row2, row2);
+}

--- a/tests/it/uuid.rs
+++ b/tests/it/uuid.rs
@@ -125,18 +125,23 @@ async fn vec_human_readable_smoke() {
     struct OursRow {
         #[serde(with = "clickhouse::serde::uuid_vec")]
         uuids: Vec<Uuid>,
+        #[serde(with = "clickhouse::serde::uuid_vec::option")]
+        uuids_opt: Option<Vec<Uuid>>,
     }
 
     #[derive(Debug, PartialEq, Eq, Serialize, Deserialize, Row)]
     struct TheirsRow {
         uuids: Vec<Uuid>,
+        uuids_opt: Option<Vec<Uuid>>,
     }
 
     let uuids = vec![Uuid::new_v4(), Uuid::new_v4()];
+    let uuids_opt = Some(vec![Uuid::new_v4(), Uuid::new_v4()]);
     let row = OursRow {
         uuids: uuids.clone(),
+        uuids_opt: uuids_opt.clone(),
     };
-    let row2 = TheirsRow { uuids };
+    let row2 = TheirsRow { uuids, uuids_opt };
 
     let s1 = serde_json::to_string(&row).unwrap();
     let s2 = serde_json::to_string(&row2).unwrap();
@@ -144,4 +149,26 @@ async fn vec_human_readable_smoke() {
 
     let new_row2: TheirsRow = serde_json::from_str(&s2).unwrap();
     assert_eq!(new_row2, row2);
+
+    let new_row: OursRow = serde_json::from_str(&s2).unwrap();
+    assert_eq!(new_row, row);
+
+    let row = OursRow {
+        uuids: Vec::new(),
+        uuids_opt: None,
+    };
+    let row2 = TheirsRow {
+        uuids: Vec::new(),
+        uuids_opt: None,
+    };
+
+    let s1 = serde_json::to_string(&row).unwrap();
+    let s2 = serde_json::to_string(&row2).unwrap();
+    assert_eq!(s1, s2);
+
+    let new_row2: TheirsRow = serde_json::from_str(&s2).unwrap();
+    assert_eq!(new_row2, row2);
+
+    let new_row: OursRow = serde_json::from_str(&s2).unwrap();
+    assert_eq!(new_row, row);
 }


### PR DESCRIPTION
## Summary
Added `serde::uuid_vec` for serializing/deserializing `Vec<uuid::Uuid>` to/from `Array(UUID)`, including an option submodule for Option<Vec<Uuid>> <--> Nullable(Array(UUID)). I have also updated the  README with a usage example in the UUID section.

## Reason
I found the need to have an array of UUID's in my data structure and clickhouse-rs does not currently support it. I tested my table against the python-sdk and it worked fine, so I thought I would implement it for clickhouse-rs as it is my primary clickhouse sdk. 


## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [x] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
