### PR TITLE
perf: move query params to POST body (fix #454)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,7 @@ jobs:
 
       - run: cargo clippy
       - run: cargo clippy --all-targets --no-default-features
+      - run: cargo clippy --lib --no-default-features --features uuid
       - run: cargo clippy --all-targets --all-features
 
       # TLS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,14 @@ jobs:
       - run: cargo miri setup
       - run: cargo miri test --all-features -- _miri
 
-  # uses a single local Docker container with a few ClickHouse versions
+  # uses a single local Docker container with current and minimum supported ClickHouse versions
   test-local:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        clickhouse: [ latest, head ]
+        # 25.8 is the minimum currently supported ClickHouse LTS release.
+        clickhouse: [ latest, head, 25.8 ]
         include:
           - clickhouse: latest
             coverage: true

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -546,7 +546,6 @@ struct EventLog {
 ## Known limitations {#known-limitations}
 
 * `Variant`, `Dynamic`, (new) `JSON` data types aren't supported yet.
-* Server-side parameter binding isn't supported yet; see [this issue](https://github.com/ClickHouse/clickhouse-rs/issues/142) for tracking.
 
 ## Contact us {#contact-us}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,6 +386,8 @@ impl Client {
 
     /// Used to specify a header that will be passed to all queries.
     ///
+    /// Headers required to frame a request body may be controlled by the client.
+    ///
     /// # Example
     /// ```
     /// # use clickhouse::Client;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -386,7 +386,10 @@ impl Client {
 
     /// Used to specify a header that will be passed to all queries.
     ///
-    /// Headers required to frame a request body may be controlled by the client.
+    /// For query requests with server-side parameters (settings named `param_*`,
+    /// including those added by [`query::Query::param`]), the client replaces
+    /// `Content-Type` and removes caller-provided `Content-Length` and
+    /// `Transfer-Encoding` so it can frame the request body.
     ///
     /// # Example
     /// ```

--- a/src/query.rs
+++ b/src/query.rs
@@ -458,7 +458,14 @@ fn multipart_query_body(
     parameters.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
 
     let boundary = multipart_boundary(query, parameters)?;
-    let mut body = Vec::new();
+    let body_capacity = parameters
+        .iter()
+        .fold(query.len(), |capacity, (name, value)| {
+            capacity
+                .saturating_add(name.len())
+                .saturating_add(value.len())
+        });
+    let mut body = Vec::with_capacity(body_capacity);
 
     append_multipart_field(&mut body, &boundary, "query", query);
     for (field_name, value) in parameters {

--- a/src/query.rs
+++ b/src/query.rs
@@ -1,4 +1,8 @@
-use hyper::{Method, Request, header::CONTENT_LENGTH};
+use bytes::Bytes;
+use hyper::{
+    Method, Request,
+    header::{CONTENT_LENGTH, CONTENT_TYPE, HeaderValue, TRANSFER_ENCODING},
+};
 use serde::Serialize;
 use std::fmt::Display;
 use tracing::Instrument;
@@ -267,13 +271,23 @@ impl Query {
             pairs.append_pair(settings::COMPRESS, "1");
         }
 
+        let mut parameters = Vec::new();
         for (name, value) in &self.client.settings {
-            pairs.append_pair(name, value);
+            if name.starts_with("param_") {
+                parameters.push((name.as_str(), value.as_str()));
+            } else {
+                pairs.append_pair(name, value);
+            }
         }
 
         pairs.extend_pairs(self.client.roles.iter().map(|role| (settings::ROLE, role)));
 
         drop(pairs);
+
+        let multipart = (!parameters.is_empty())
+            .then(|| multipart_query_body(&query, &mut parameters))
+            .transpose()
+            .inspect_err(|err| err.record_in_current_span("invalid params in query"))?;
 
         let mut builder = Request::builder().method(Method::POST).uri(url.as_str());
         builder = with_request_headers(builder, &self.client.headers, &self.client.products_info);
@@ -284,10 +298,31 @@ impl Query {
             builder = builder.header("Accept-Encoding", "zstd");
         }
 
-        let content_length = query.len();
-        builder = builder.header(CONTENT_LENGTH, content_length.to_string());
+        let body = if let Some(multipart) = multipart {
+            // The client controls headers that frame this body. `headers_mut()` is
+            // `None` if a caller-provided header has already invalidated the builder;
+            // leave that error intact for `builder.body()` below.
+            if let Some(headers) = builder.headers_mut() {
+                headers.remove(CONTENT_LENGTH);
+                headers.remove(TRANSFER_ENCODING);
+                headers.insert(
+                    CONTENT_TYPE,
+                    HeaderValue::from_str(&multipart.content_type).map_err(|err| {
+                        let err = Error::InvalidParams(Box::new(err));
+                        err.record_in_current_span("invalid params in query");
+                        err
+                    })?,
+                );
+            }
 
-        let request = builder.body(RequestBody::full(query)).map_err(|err| {
+            RequestBody::full(multipart.body)
+        } else {
+            // Retain the raw SQL request format for parameter-free queries.
+            builder = builder.header(CONTENT_LENGTH, query.len().to_string());
+            RequestBody::full(query)
+        };
+
+        let request = builder.body(body).map_err(|err| {
             let err = Error::InvalidParams(Box::new(err));
             err.record_in_current_span("invalid params in query");
             err
@@ -351,9 +386,13 @@ impl Query {
         }
     }
 
-    /// Specify server side parameter for query.
+    /// Specify a ClickHouse server-side query parameter.
     ///
-    /// In queries, you can reference params as {name: type} e.g. {val: Int32}.
+    /// This creates a ClickHouse `param_<name>` request parameter. In queries,
+    /// you can reference parameters as `{name: Type}`, for example
+    /// `{val: Int32}`. `name` must match the supported bare identifier grammar:
+    /// `[A-Za-z_][A-Za-z0-9_]*`. An invalid name returns [`Error::InvalidParams`]
+    /// during execution.
     pub fn param(mut self, name: &str, value: impl Serialize) -> Self {
         let mut param = String::from("");
         if let Err(err) = ser::write_param(&mut param, &value) {
@@ -393,6 +432,442 @@ mod tests {
         assert!(
             err_str.contains("client_protocol_version"),
             "unexpected error: {err_str:?}"
+        );
+    }
+}
+
+const MULTIPART_BOUNDARY_PREFIX: &str = "clickhouse-rs-boundary-";
+
+struct MultipartQueryBody {
+    body: Bytes,
+    content_type: String,
+}
+
+fn multipart_query_body(
+    query: &str,
+    parameters: &mut [(&str, &str)],
+) -> Result<MultipartQueryBody> {
+    for (field_name, _) in parameters.iter() {
+        if !is_valid_parameter_field_name(field_name) {
+            return Err(invalid_params(format!(
+                "invalid ClickHouse query parameter name: {field_name:?}"
+            )));
+        }
+    }
+
+    parameters.sort_unstable_by(|(left, _), (right, _)| left.cmp(right));
+
+    let boundary = multipart_boundary(query, parameters)?;
+    let mut body = Vec::new();
+
+    append_multipart_field(&mut body, &boundary, "query", query);
+    for (field_name, value) in parameters {
+        append_multipart_field(&mut body, &boundary, field_name, value);
+    }
+    body.extend_from_slice(b"--");
+    body.extend_from_slice(boundary.as_bytes());
+    body.extend_from_slice(b"--\r\n");
+
+    Ok(MultipartQueryBody {
+        body: Bytes::from(body),
+        content_type: format!("multipart/form-data; boundary={boundary}"),
+    })
+}
+
+fn is_valid_parameter_field_name(field_name: &str) -> bool {
+    let Some(name) = field_name.strip_prefix("param_") else {
+        return false;
+    };
+    let mut chars = name.bytes();
+    matches!(chars.next(), Some(b'a'..=b'z' | b'A'..=b'Z' | b'_'))
+        && chars.all(|byte| byte.is_ascii_alphanumeric() || byte == b'_')
+}
+
+fn multipart_boundary(query: &str, parameters: &[(&str, &str)]) -> Result<String> {
+    let mut suffix = 0_usize;
+    loop {
+        let boundary = format!("{MULTIPART_BOUNDARY_PREFIX}{suffix}");
+        if !payload_contains_boundary(query, &boundary)
+            && parameters
+                .iter()
+                .all(|(_, value)| !payload_contains_boundary(value, &boundary))
+        {
+            return Ok(boundary);
+        }
+
+        suffix = suffix
+            .checked_add(1)
+            .ok_or_else(|| invalid_params("unable to construct multipart query body"))?;
+    }
+}
+
+fn payload_contains_boundary(payload: &str, boundary: &str) -> bool {
+    payload.starts_with(&format!("--{boundary}")) || payload.contains(&format!("\r\n--{boundary}"))
+}
+
+fn append_multipart_field(body: &mut Vec<u8>, boundary: &str, name: &str, value: &str) {
+    body.extend_from_slice(b"--");
+    body.extend_from_slice(boundary.as_bytes());
+    body.extend_from_slice(b"\r\nContent-Disposition: form-data; name=\"");
+    body.extend_from_slice(name.as_bytes());
+    body.extend_from_slice(b"\"\r\n\r\n");
+    body.extend_from_slice(value.as_bytes());
+    body.extend_from_slice(b"\r\n");
+}
+
+fn invalid_params(message: impl Into<String>) -> Error {
+    Error::InvalidParams(Box::new(std::io::Error::new(
+        std::io::ErrorKind::InvalidInput,
+        message.into(),
+    )))
+}
+
+#[cfg(test)]
+mod multipart_tests {
+    use super::*;
+
+    #[test]
+    fn post_query_params_multipart_body() {
+        let query = "SELECT {a: String}";
+        let mut parameters = [("param_z", "last"), ("param_a", "first")];
+
+        let multipart = multipart_query_body(query, &mut parameters).unwrap();
+        let boundary = multipart
+            .content_type
+            .strip_prefix("multipart/form-data; boundary=")
+            .unwrap();
+        let expected = format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"query\"\r\n\r\n{query}\r\n\
+             --{boundary}\r\nContent-Disposition: form-data; name=\"param_a\"\r\n\r\nfirst\r\n\
+             --{boundary}\r\nContent-Disposition: form-data; name=\"param_z\"\r\n\r\nlast\r\n\
+             --{boundary}--\r\n"
+        );
+
+        assert_eq!(multipart.body, expected);
+    }
+
+    #[test]
+    fn post_query_params_boundary_collisions() {
+        let boundary = format!("{MULTIPART_BOUNDARY_PREFIX}0");
+        let value = format!("\r\n--{boundary}inside");
+        let mut parameters = [("param_value", value.as_str())];
+        let multipart =
+            multipart_query_body(&format!("--{boundary}at-the-start"), &mut parameters).unwrap();
+
+        assert_eq!(
+            multipart.content_type,
+            format!("multipart/form-data; boundary={MULTIPART_BOUNDARY_PREFIX}1")
+        );
+    }
+
+    #[test]
+    fn post_query_params_identifier_validation() {
+        for name in ["param_a", "param_A9", "param__"] {
+            assert!(is_valid_parameter_field_name(name), "{name}");
+        }
+        for name in [
+            "param_",
+            "param_9a",
+            "param_a-b",
+            "param_a\nb",
+            "param_a\rb",
+            "param_a\0b",
+            "param_a\"b",
+            "param_a\\b",
+        ] {
+            assert!(!is_valid_parameter_field_name(name), "{name:?}");
+            assert!(multipart_query_body("SELECT 1", &mut [(name, "value")]).is_err());
+        }
+    }
+}
+
+#[cfg(all(test, feature = "test-util"))]
+mod transport_tests {
+    use super::*;
+    use crate::test;
+    use hyper::Request;
+
+    fn parse_multipart_fields(request: &Request<Bytes>) -> Vec<(String, Vec<u8>)> {
+        let content_type = request
+            .headers()
+            .get_all(CONTENT_TYPE)
+            .iter()
+            .map(|value| value.to_str().unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(content_type.len(), 1);
+        let boundary = content_type[0]
+            .strip_prefix("multipart/form-data; boundary=")
+            .expect("multipart content type");
+        let opening = format!("--{boundary}\r\n");
+        let marker = format!("\r\n--{boundary}");
+        let closing = b"--\r\n";
+        let mut input = request
+            .body()
+            .strip_prefix(opening.as_bytes())
+            .expect("opening boundary");
+        let mut fields = Vec::new();
+
+        loop {
+            let header_end = find_bytes(input, b"\r\n\r\n").expect("field headers");
+            let headers = std::str::from_utf8(&input[..header_end]).expect("UTF-8 headers");
+            let name = headers
+                .strip_prefix("Content-Disposition: form-data; name=\"")
+                .and_then(|header| header.strip_suffix('"'))
+                .expect("only a Content-Disposition header")
+                .to_owned();
+            input = &input[header_end + 4..];
+
+            let value_end = find_bytes(input, marker.as_bytes()).expect("next boundary");
+            fields.push((name, input[..value_end].to_vec()));
+            input = &input[value_end + marker.len()..];
+
+            if input.starts_with(closing) {
+                assert_eq!(&input[closing.len()..], b"");
+                return fields;
+            }
+            input = input
+                .strip_prefix(b"\r\n")
+                .expect("field boundary terminator");
+        }
+    }
+
+    fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+        haystack
+            .windows(needle.len())
+            .position(|window| window == needle)
+    }
+
+    fn assert_single_content_length(request: &Request<Bytes>) {
+        let content_length = request
+            .headers()
+            .get_all(CONTENT_LENGTH)
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(content_length.len(), 1);
+        assert_eq!(
+            content_length[0]
+                .to_str()
+                .unwrap()
+                .parse::<usize>()
+                .unwrap(),
+            request.body().len()
+        );
+    }
+
+    #[tokio::test]
+    async fn post_query_params_transport() {
+        let mock = test::Mock::new();
+        let record = mock.add(test::handlers::record_request());
+        let client = Client::default()
+            .with_mock(&mock)
+            .with_database("test_db")
+            .with_roles(["reader", "writer"])
+            .with_setting("max_block_size", "123")
+            .with_setting("param_z", "last");
+        #[cfg(feature = "lz4")]
+        let client = client.with_compression(Compression::Lz4);
+
+        let mut cursor = client
+            .query("SELECT {a: UInt8}, {z: String}")
+            .param("a", 42)
+            .fetch::<String>()
+            .unwrap();
+        assert!(cursor.next().await.unwrap().is_none());
+
+        let request = record.request().await;
+        assert_eq!(request.method(), Method::POST);
+        assert_single_content_length(&request);
+
+        let pairs = url::form_urlencoded::parse(request.uri().query().unwrap().as_bytes())
+            .map(|(name, value)| (name.into_owned(), value.into_owned()))
+            .collect::<Vec<_>>();
+        for expected in [
+            ("database", "test_db"),
+            ("default_format", "RowBinary"),
+            ("max_block_size", "123"),
+            ("role", "reader"),
+            ("role", "writer"),
+        ] {
+            assert!(
+                pairs
+                    .iter()
+                    .any(|(name, value)| name == expected.0 && value == expected.1),
+                "missing {expected:?} in {pairs:?}"
+            );
+        }
+        assert!(!pairs.iter().any(|(name, _)| name.starts_with("param_")));
+        #[cfg(feature = "lz4")]
+        assert!(
+            pairs
+                .iter()
+                .any(|(name, value)| name == "compress" && value == "1"),
+            "missing compression setting in {pairs:?}"
+        );
+
+        assert_eq!(
+            parse_multipart_fields(&request),
+            vec![
+                (
+                    "query".to_owned(),
+                    b"SELECT {a: UInt8}, {z: String}".to_vec()
+                ),
+                ("param_a".to_owned(), b"42".to_vec()),
+                ("param_z".to_owned(), b"last".to_vec()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn post_query_params_transport_controls_framing_headers() {
+        let mock = test::Mock::new();
+        let record = mock.add(test::handlers::record_request());
+        let client = Client::default()
+            .with_mock(&mock)
+            .with_header("Content-Type", "text/plain")
+            .with_header("content-type", "application/json")
+            .with_header("Content-Length", "1")
+            .with_header("content-length", "2")
+            .with_header("Transfer-Encoding", "chunked");
+
+        client
+            .query("SELECT {value: UInt8}")
+            .param("value", 1)
+            .execute()
+            .await
+            .unwrap();
+
+        let request = record.request().await;
+        let content_types = request
+            .headers()
+            .get_all(CONTENT_TYPE)
+            .iter()
+            .collect::<Vec<_>>();
+        assert_eq!(content_types.len(), 1);
+        assert!(
+            content_types[0]
+                .to_str()
+                .unwrap()
+                .starts_with("multipart/form-data; boundary=")
+        );
+        assert_single_content_length(&request);
+        assert!(request.headers().get(TRANSFER_ENCODING).is_none());
+    }
+
+    #[cfg(feature = "zstd")]
+    #[tokio::test]
+    async fn post_query_params_transport_keeps_zstd_negotiation() {
+        let mock = test::Mock::new();
+        let record = mock.add(test::handlers::record_request());
+
+        Client::default()
+            .with_mock(&mock)
+            .with_compression(Compression::zstd())
+            .query("SELECT {value: UInt8}")
+            .param("value", 1)
+            .execute()
+            .await
+            .unwrap();
+
+        let request = record.request().await;
+        let pairs = url::form_urlencoded::parse(request.uri().query().unwrap().as_bytes())
+            .collect::<Vec<_>>();
+        assert!(
+            pairs
+                .iter()
+                .any(|(name, value)| { name == settings::ENABLE_HTTP_COMPRESSION && value == "1" })
+        );
+        assert_eq!(
+            request.headers().get("Accept-Encoding"),
+            Some(&HeaderValue::from_static("zstd"))
+        );
+        assert_eq!(
+            parse_multipart_fields(&request),
+            vec![
+                ("query".to_owned(), b"SELECT {value: UInt8}".to_vec()),
+                ("param_value".to_owned(), b"1".to_vec()),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn post_query_params_transport_rejects_invalid_names_and_headers() {
+        for suffix in ["", "a\nb", "a\rb", "a\0b", "a\"b", "a\\b"] {
+            let mut mock = test::Mock::new();
+            mock.add(test::handlers::failure(test::status::INTERNAL_SERVER_ERROR));
+            mock.non_exhaustive();
+            let error = Client::default()
+                .with_mock(&mock)
+                .query("SELECT {value: String}")
+                .with_setting(format!("param_{suffix}"), "value")
+                .execute()
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, Error::InvalidParams(_)),
+                "{suffix:?}: {error:?}"
+            );
+        }
+
+        for (name, value) in [("invalid header", "value"), ("X-Test", "bad\nvalue")] {
+            let mut mock = test::Mock::new();
+            mock.add(test::handlers::failure(test::status::INTERNAL_SERVER_ERROR));
+            mock.non_exhaustive();
+            let error = Client::default()
+                .with_mock(&mock)
+                .with_header(name, value)
+                .query("SELECT {value: UInt8}")
+                .param("value", 1)
+                .execute()
+                .await
+                .unwrap_err();
+            assert!(
+                matches!(error, Error::InvalidParams(_)),
+                "{name:?}: {error:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn post_query_params_transport_keeps_raw_queries_unchanged() {
+        let mock = test::Mock::new();
+        let record = mock.add(test::handlers::record_request());
+
+        Client::default()
+            .with_mock(&mock)
+            .query("SELECT 1")
+            .execute()
+            .await
+            .unwrap();
+
+        let request = record.request().await;
+        assert_eq!(request.body(), &Bytes::from_static(b"SELECT 1"));
+        assert!(request.headers().get(CONTENT_TYPE).is_none());
+        assert_single_content_length(&request);
+    }
+
+    #[tokio::test]
+    async fn post_query_params_transport_preserves_last_write_wins() {
+        let mock = test::Mock::new();
+        let record = mock.add(test::handlers::record_request());
+        let client = Client::default()
+            .with_mock(&mock)
+            .with_setting("param_value", "client");
+
+        client
+            .query("SELECT {value: String}")
+            .param("value", "query-param")
+            .with_setting("param_value", "query-setting")
+            .execute()
+            .await
+            .unwrap();
+
+        let request = record.request().await;
+        assert_eq!(
+            parse_multipart_fields(&request),
+            vec![
+                ("query".to_owned(), b"SELECT {value: String}".to_vec()),
+                ("param_value".to_owned(), b"query-setting".to_vec()),
+            ]
         );
     }
 }

--- a/src/request_body.rs
+++ b/src/request_body.rs
@@ -24,8 +24,8 @@ enum Message {
 }
 
 impl RequestBody {
-    pub(crate) fn full(content: String) -> Self {
-        Self(Inner::Full(Bytes::from(content)))
+    pub(crate) fn full(content: impl Into<Bytes>) -> Self {
+        Self(Inner::Full(content.into()))
     }
 
     pub(crate) fn chunked() -> (ChunkSender, Self) {

--- a/src/rowbinary/tests.rs
+++ b/src/rowbinary/tests.rs
@@ -106,6 +106,23 @@ fn sample() -> Sample<'static> {
     }
 }
 
+#[cfg(feature = "uuid")]
+#[derive(Debug, PartialEq, Serialize, Deserialize)]
+struct NullableUuidVec {
+    #[serde(with = "crate::serde::uuid_vec::option")]
+    uuids: Option<Vec<uuid::Uuid>>,
+}
+
+#[cfg(feature = "uuid")]
+impl Row for NullableUuidVec {
+    const NAME: &'static str = "NullableUuidVec";
+    const COLUMN_NAMES: &'static [&'static str] = &["uuids"];
+    const COLUMN_COUNT: usize = 1;
+    const KIND: crate::row::RowKind = crate::row::RowKind::Struct;
+
+    type Value<'a> = NullableUuidVec;
+}
+
 fn sample_serialized() -> Vec<u8> {
     vec![
         // [Int8] -42
@@ -177,6 +194,43 @@ fn it_deserializes() {
 
         let actual: Sample<'_> = super::deserialize_row(&mut input.as_slice(), None).unwrap();
         assert_eq!(actual, sample());
+    }
+}
+
+#[cfg(feature = "uuid")]
+#[test]
+fn it_round_trips_nullable_uuid_vec() {
+    for expected in [
+        NullableUuidVec {
+            uuids: Some(vec![
+                uuid::Uuid::from_u64_pair(0x1234_5678_9abc_def0, 0xfedc_ba98_7654_3210),
+                uuid::Uuid::from_u64_pair(0x0fed_cba9_8765_4321, 0x0123_4567_89ab_cdef),
+            ]),
+        },
+        NullableUuidVec { uuids: None },
+    ] {
+        let expected_bytes = match &expected.uuids {
+            Some(uuids) => {
+                let mut bytes = vec![0, uuids.len() as u8];
+                for uuid in uuids {
+                    let (high, low) = uuid.as_u64_pair();
+                    bytes.extend_from_slice(&high.to_le_bytes());
+                    bytes.extend_from_slice(&low.to_le_bytes());
+                }
+                bytes
+            }
+            None => vec![1],
+        };
+
+        let mut bytes = Vec::new();
+        super::serialize_row_binary(&mut bytes, &expected).unwrap();
+        assert_eq!(bytes, expected_bytes);
+
+        let mut input = bytes.as_slice();
+        let actual: NullableUuidVec = super::deserialize_row(&mut input, None).unwrap();
+
+        assert!(input.is_empty());
+        assert_eq!(actual, expected);
     }
 }
 

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -114,6 +114,60 @@ pub mod uuid_vec {
     use serde::ser::SerializeSeq;
     use std::fmt;
 
+    pub mod option {
+        use super::*;
+        use ::uuid::Uuid;
+
+        pub fn serialize<S>(uuids: &Option<Vec<Uuid>>, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            struct UuidVec<'a>(&'a [Uuid]);
+
+            impl Serialize for UuidVec<'_> {
+                fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+                    super::serialize(self.0, serializer)
+                }
+            }
+
+            match uuids {
+                Some(uuids) => serializer.serialize_some(&UuidVec(uuids)),
+                None => serializer.serialize_none(),
+            }
+        }
+
+        pub fn deserialize<'de, D>(deserializer: D) -> Result<Option<Vec<Uuid>>, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct OptionUuidVecVisitor;
+
+            impl<'de> Visitor<'de> for OptionUuidVecVisitor {
+                type Value = Option<Vec<Uuid>>;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an optional sequence of UUID values")
+                }
+
+                fn visit_none<E>(self) -> Result<Self::Value, E>
+                where
+                    E: serde::de::Error,
+                {
+                    Ok(None)
+                }
+
+                fn visit_some<D>(self, deserializer: D) -> Result<Self::Value, D::Error>
+                where
+                    D: Deserializer<'de>,
+                {
+                    super::deserialize(deserializer).map(Some)
+                }
+            }
+
+            deserializer.deserialize_option(OptionUuidVecVisitor)
+        }
+    }
+
     pub fn serialize<S>(uuids: &[Uuid], serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,

--- a/src/test/handlers.rs
+++ b/src/test/handlers.rs
@@ -137,6 +137,47 @@ pub fn record<T>() -> impl Handler<Control = RecordControl<T>> {
     RecordHandler(PhantomData)
 }
 
+// === record_request ===
+
+#[cfg(test)]
+struct RecordRequestHandler;
+
+#[cfg(test)]
+impl super::sealed::Sealed for RecordRequestHandler {}
+
+#[cfg(test)]
+impl super::Handler for RecordRequestHandler {
+    type Control = RecordRequestControl;
+
+    #[doc(hidden)]
+    fn make(self) -> (HandlerFn, Self::Control) {
+        let (tx, rx) = oneshot::channel();
+        let control = RecordRequestControl(rx);
+
+        let handler = Box::new(move |request: Request<Bytes>| -> Response<Bytes> {
+            let _ = tx.send(request);
+            Response::new(Bytes::new())
+        });
+
+        (handler, control)
+    }
+}
+
+#[cfg(test)]
+pub(crate) struct RecordRequestControl(oneshot::Receiver<Request<Bytes>>);
+
+#[cfg(test)]
+impl RecordRequestControl {
+    pub(crate) async fn request(self) -> Request<Bytes> {
+        self.0.await.expect("query canceled")
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn record_request() -> impl Handler<Control = RecordRequestControl> {
+    RecordRequestHandler
+}
+
 // === record_ddl ===
 
 struct RecordDdlHandler;

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -155,7 +155,9 @@ async fn server_side_param() {
 #[tokio::test]
 async fn post_query_params_large_array() {
     let client = prepare_database!();
-    let values = (0..128)
+    // Keep the serialized form field within ClickHouse's default 128 KiB
+    // `http_max_field_value_size`.
+    let values = (0..120)
         .map(|index| format!("{index:03}-{}", "x".repeat(1024)))
         .collect::<Vec<_>>();
 
@@ -166,7 +168,7 @@ async fn post_query_params_large_array() {
         .await
         .expect("failed to execute query with a large parameter");
 
-    assert_eq!(length, 128);
+    assert_eq!(length, 120);
 }
 
 // See #19.

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -143,7 +143,7 @@ async fn server_side_param() {
     assert_eq!(result, bytes);
 
     let result = client
-        .query("SELECT getSetting('max_block_size') WHERE {value: UInt8} = 1")
+        .query("SELECT toUInt64(getSetting('max_block_size')) WHERE {value: UInt8} = 1")
         .with_setting("max_block_size", "123")
         .param("value", 1)
         .fetch_one::<u64>()

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -141,6 +141,32 @@ async fn server_side_param() {
         .await
         .expect("failed to fetch bytes");
     assert_eq!(result, bytes);
+
+    let result = client
+        .query("SELECT getSetting('max_block_size') WHERE {value: UInt8} = 1")
+        .with_setting("max_block_size", "123")
+        .param("value", 1)
+        .fetch_one::<u64>()
+        .await
+        .expect("failed to apply an ordinary setting to a parameterized query");
+    assert_eq!(result, 123);
+}
+
+#[tokio::test]
+async fn post_query_params_large_array() {
+    let client = prepare_database!();
+    let values = (0..128)
+        .map(|index| format!("{index:03}-{}", "x".repeat(1024)))
+        .collect::<Vec<_>>();
+
+    let length = client
+        .query("SELECT length({value: Array(String)})")
+        .param("value", values)
+        .fetch_one::<u64>()
+        .await
+        .expect("failed to execute query with a large parameter");
+
+    assert_eq!(length, 128);
 }
 
 // See #19.


### PR DESCRIPTION
## Summary

Fixes #454. 

Server-side query parameters supplied with [`Query::param()`] are now sent as `multipart/form-data` fields in the POST request body instead of URI query parameters. This avoids URI-length limits when queries bind many parameters or large values.  

## Candidate CHANGELOG entry

```
 * Server-side query parameters supplied with [`Query::param()`] are now sent as              
     `multipart/form-data` fields in the POST request body instead of URI query                 
     parameters. This avoids URI-length limits when queries bind many parameters                
     or large values.                                                                           
     * The `Query::param()` API and parameter serialization are unchanged; callers              
       should see the same ClickHouse query semantics.                                          
     * Settings named `param_*` follow the same behavior.                                       
     * For parameterized queries, clickhouse-rs now controls HTTP body-framing                  
       headers: it sets the multipart `Content-Type` and removes caller-provided                
       `Content-Length` and `Transfer-Encoding`. Applications that set, sign, or                
       otherwise depend on those headers must update their request configuration.     
```

Note the point about the HTTP headers. For users setting custom headers, this is a breaking change.

## Implementation Notes

`Query::param()` continues to serialize values with the existing parameter serializer and records them as `param_<name>` settings. While building a query request, clickhouse-rs now separates those `param_*` settings from ordinary ClickHouse settings:                                                                         
                                                                                                
   - Ordinary settings and roles remain URI query parameters.                                   
   - When parameters are present, the request becomes a `multipart/form-data` POST body containing a `query` field followed by one field per `param_<name>`.                                                                            
   - Parameter fields are sorted for deterministic request construction. The multipart boundary is chosen to avoid collisions with the query or parameter values, and parameter names are validated before being used as form-field names.                                                                                     
   - clickhouse-rs sets the multipart `Content-Type` and removes caller-supplied `Content-Length` and `Transfer-Encoding`, allowing the HTTP body implementation to frame the request correctly.                                        
   - Parameter-free queries retain the previous raw-SQL POST body and explicit `Content-Length` behavior.                                                                 
                                                                                                
Unit tests cover multipart field construction, boundary collisions, parameter validation, header handling, compression, and preservation of ordinary settings. Integration coverage includes parameterized queries with large values that would otherwise approach URI-length limits.                                      
                                                                                                
The branch also fixes the opt-in `uuid` RowBinary adapter for `Option<Vec<Uuid>>`. Its optional wrapper now delegates `Some` values through the crate's UUID-vector serializer/deserializer, preserving ClickHouse's binary UUID representation. Regression tests cover both nullable states.        

### On the UUID RowBinary change

I use clickhouse-rs via diesel-clickhouse, and I use UUIDs a lot which is how I found this.

This is a targeted fix for structs that map a Rust `Option<Vec<uuid::Uuid>>` to a ClickHouse `Nullable(Array(UUID))` column using `#[serde(with = "clickhouse::serde::uuid_vec::option")]`.

For RowBinary, a non-null `Nullable(...)` value starts with a `0` byte; `NULL` is represented by `1`. A present `Array(UUID)` then contains its length, followed by each UUID encoded as two little-endian `u64` values.

Previously, serializing `Some(vec)` delegated directly to the UUID-vector adapter. That adapter correctly encoded the array and UUID elements, but bypassed Serde's outer `Option` handling, so it omitted the required leading `0` non-null marker. The generated bytes were therefore not valid `Nullable(Array(UUID))` RowBinary.

The old deserializer had the inverse problem: it handled the outer `Option` but delegated a present vector to Serde's generic `Vec<Uuid>` implementation, rather than the crate's UUID-vector adapter. It consequently could not deserialize valid non-null `Nullable(Array(UUID))` bytes.

The fix preserves the outer `Option` layer and delegates only its present inner value to the UUID-vector adapter. The regression test verifies exact bytes and round-trips both `Some(vec![...])` and `None`.

`None` was already encoded correctly. This change is behind the opt-in `uuid` feature and is independent of the multipart query-parameter change. I do need it for diesel-clickhouse though.

## Checklist
Delete items not relevant to your PR:
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later