### PR TITLE
fix(types): parse back-quoted JSON path names

### DIFF
--- a/tests/it/insert.rs
+++ b/tests/it/insert.rs
@@ -206,6 +206,68 @@ async fn insert_with_json_hint() {
 }
 
 #[tokio::test]
+async fn insert_with_json_hint_and_quoted_paths() {
+    #[derive(Serialize, Deserialize, Row, PartialEq)]
+    struct JSONTestRow {
+        i: u8,
+        jv: String,
+    }
+
+    let table_name = "rust_json_quoted_paths_test";
+
+    let client = prepare_database!()
+        .with_setting("input_format_binary_read_json_as_string", "1")
+        .with_setting("output_format_binary_write_json_as_string", "1");
+
+    // the server back-quotes these paths in the column type it reports,
+    // i.e. JSON(`foo bar` String, `baz,qux` Int64)
+    client
+        .query(
+            r#"
+                CREATE TABLE ? (
+                    i UInt8,
+                    jv JSON(
+                        `foo bar` String,
+                        `baz,qux` Int64
+                    )
+                )
+                ENGINE = MergeTree
+                ORDER BY i
+            "#,
+        )
+        .bind(Identifier(table_name))
+        .execute()
+        .await
+        .unwrap();
+
+    let row = JSONTestRow {
+        i: 1,
+        jv: r#"{
+            "foo bar": "hello",
+            "baz,qux": 123
+        }"#
+        .to_string(),
+    };
+
+    let mut insert = client.insert::<JSONTestRow>(table_name).await.unwrap();
+
+    insert.write(&row).await.unwrap();
+
+    insert.end().await.unwrap();
+
+    let rows = fetch_rows::<JSONTestRow>(&client, table_name).await;
+
+    assert!(rows.len() == 1);
+
+    assert_eq!(
+        serde_json::from_str::<Value>(&rows[0].jv).unwrap(),
+        serde_json::from_str::<Value>(&row.jv).unwrap()
+    );
+
+    assert_eq!(rows[0].i, row.i)
+}
+
+#[tokio::test]
 async fn rename_insert() {
     #[derive(Debug, Row, Serialize, Deserialize, PartialEq)]
     #[serde(rename_all = "camelCase")]

--- a/types/src/data_types.rs
+++ b/types/src/data_types.rs
@@ -711,16 +711,30 @@ fn parse_map(input: &str) -> Result<DataTypeNode, TypesError> {
 }
 
 fn parse_json(input: &str) -> Result<DataTypeNode, TypesError> {
-    let columns = remove_json_header(input)?.split(',').collect::<Vec<_>>();
+    let hints = remove_json_header(input)?;
+
+    let mut columns = Vec::new();
+    let mut last_element_index = 0;
+    for i in unquoted_positions(hints, b',') {
+        columns.push(&hints[last_element_index..i]);
+        last_element_index = i + 1;
+    }
+    columns.push(&hints[last_element_index..]);
 
     let inner_types = columns
         .into_iter()
         .map(|column| column.trim())
-        .filter(|column| !column.contains('=') && !column.starts_with("SKIP"))
+        .filter(|column| {
+            unquoted_positions(column, b'=').next().is_none() && !column.starts_with("SKIP")
+        })
         .map(|column| {
-            let map = column.split(' ').collect::<Vec<_>>();
-            let key_type = map[0].to_string();
-            let value_type = DataTypeNode::new(map[1])?;
+            let separator_index = unquoted_positions(column, b' ').next().ok_or_else(|| {
+                TypesError::TypeParsingError(format!(
+                    "Invalid JSON type hint, expected `path Type`, got {column} in {input}"
+                ))
+            })?;
+            let key_type = column[..separator_index].to_string();
+            let value_type = DataTypeNode::new(column[separator_index + 1..].trim_start())?;
 
             Ok((key_type, Box::new(value_type)))
         })
@@ -731,6 +745,32 @@ fn parse_json(input: &str) -> Result<DataTypeNode, TypesError> {
     }
 
     Ok(DataTypeNode::JsonWithHint(inner_types))
+}
+
+/// Yields the indices of every `separator` byte in `input` that is not inside a
+/// back-quoted identifier. A JSON path name is back-quoted by the server when it
+/// contains a character that requires quoting, so both the separator between the
+/// hints and the one between a path and its type have to skip such spans:
+/// ```text
+///  let input = "`a,b` Int64, `c d` String"; // two hints, not four
+/// ```
+/// A back-quote escaped with a backslash does not end the identifier.
+fn unquoted_positions(input: &str, separator: u8) -> impl Iterator<Item = usize> + '_ {
+    let mut quote_open = false;
+    let mut char_escaped = false;
+
+    input.bytes().enumerate().filter_map(move |(i, byte)| {
+        if char_escaped {
+            char_escaped = false;
+        } else if byte == b'\\' {
+            char_escaped = true;
+        } else if byte == b'`' {
+            quote_open = !quote_open;
+        } else if byte == separator && !quote_open {
+            return Some(i);
+        }
+        None
+    })
 }
 
 fn remove_json_header(input: &str) -> Result<&str, TypesError> {
@@ -1476,6 +1516,51 @@ mod tests {
         assert!(DataTypeNode::new("Map(Int32, V)").is_err());
         assert!(DataTypeNode::new("Map(K, Int32)").is_err());
         assert!(DataTypeNode::new("Map(String, Int32").is_err());
+    }
+
+    #[test]
+    fn test_data_type_new_json_with_quoted_paths() {
+        // ClickHouse back-quotes a JSON path when its name contains a character
+        // that requires quoting, such as a space or a comma
+        assert_eq!(
+            DataTypeNode::new("JSON(`a b` Int64)").unwrap(),
+            DataTypeNode::JsonWithHint(vec![("`a b`".to_string(), Box::new(DataTypeNode::Int64))])
+        );
+        assert_eq!(
+            DataTypeNode::new("JSON(`a,b` Int64)").unwrap(),
+            DataTypeNode::JsonWithHint(vec![("`a,b`".to_string(), Box::new(DataTypeNode::Int64))])
+        );
+        // an escaped back-quote does not end the quoted path
+        assert_eq!(
+            DataTypeNode::new("JSON(`a\\`,b` Int64)").unwrap(),
+            DataTypeNode::JsonWithHint(vec![(
+                "`a\\`,b`".to_string(),
+                Box::new(DataTypeNode::Int64)
+            )])
+        );
+        assert_eq!(
+            DataTypeNode::new("JSON(`a,b` Int64, `c d` String, e UInt8)").unwrap(),
+            DataTypeNode::JsonWithHint(vec![
+                ("`a,b`".to_string(), Box::new(DataTypeNode::Int64)),
+                ("`c d`".to_string(), Box::new(DataTypeNode::String)),
+                ("e".to_string(), Box::new(DataTypeNode::UInt8)),
+            ])
+        );
+        // settings are still skipped, and a quoted path is not mistaken for one
+        assert_eq!(
+            DataTypeNode::new("JSON(max_dynamic_types=8, SKIP a, `b=c` Int64)").unwrap(),
+            DataTypeNode::JsonWithHint(vec![("`b=c`".to_string(), Box::new(DataTypeNode::Int64))])
+        );
+        // a hint without a type is an error instead of a panic
+        assert!(DataTypeNode::new("JSON(`a,b`)").is_err());
+        // the parsed type is sent back to the server as is, so quoting must survive
+        for input in [
+            "JSON(`a b` Int64)",
+            "JSON(`a,b` Int64)",
+            "JSON(`a,b` Int64, `c d` String, e UInt8)",
+        ] {
+            assert_eq!(DataTypeNode::new(input).unwrap().to_string(), input);
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #453.

ClickHouse back-quotes a `JSON` typed path when its name contains a character that requires quoting, and reports the column type that way in the `RowBinaryWithNamesAndTypes` header:

```
$ curl -s --data-binary "SELECT toTypeName('{\"a b\":1}'::JSON(\`a b\` Int64)) AS t, toTypeName('{}'::JSON(\`a,b\` Int64)) AS t2 FORMAT TSV" http://localhost:8123/
JSON(`a b` Int64)	JSON(`a,b` Int64)
```

`parse_json()` split the hint list on every comma and each hint on every space, with no awareness of those quotes:

* `` JSON(`a,b` Int64) `` was split into `` `a `` and `` b` Int64 ``. The first fragment contains no space, so `map` had a single element and `map[1]` panicked with `index out of bounds: the len is 1 but the index is 1` — a panic in library code rather than a returned `Err`.
* `` JSON(`a b` Int64) `` yielded the key `` `a `` and the type `` b` ``, failing with `Unknown data type: b\``.

Both happen while parsing the columns header, so the whole query fails — reading or inserting into any table with such a column is impossible, and there is no way to opt out.

## The fix

Splitting is now done on separators that are outside a back-quoted span, both for the hint list and for the path/type boundary inside a hint (a back-quote escaped with a backslash does not end the span, matching how the server escapes it). The same applies to the `=` check that tells a JSON setting such as `max_dynamic_types=8` apart from a path hint, so a path named `` `b=c` `` is no longer silently dropped. Where the old code indexed `map[1]` blindly, a hint with no type now returns a `TypeParsingError`.

This is the right layer for it: the quoting is part of the type as the server spells it, and `parse_json()` is the only place that takes it apart.

Path names are deliberately kept **exactly as the server wrote them**, quotes included, rather than being unquoted. `DataTypeNode`'s `Display` impl is used by `put_rbwnat_columns_header()` to send the type back on INSERT, so keeping the name verbatim makes that round-trip byte-identical; unquoting the name would silently produce an invalid `JSON(a b Int64)` header unless `Display` learned to re-quote and re-escape. That is a separate change, so I left it out here — the unit test pins the round-trip so the two sides cannot drift apart.

Not addressed, and independent of this: #442, where `remove_json_header()` trims *all* trailing `)` and so mangles a nested type argument like `Nullable(String)`. A fix for that would not have helped the back-quoted cases and vice versa.

## Verification

Unit test, on `main` before the fix:

```
$ cargo test -p clickhouse-types --lib test_data_type_new_json_with_quoted_paths

running 1 test
test data_types::tests::test_data_type_new_json_with_quoted_paths ... FAILED

---- data_types::tests::test_data_type_new_json_with_quoted_paths stdout ----

thread 'data_types::tests::test_data_type_new_json_with_quoted_paths' panicked at types/src/data_types.rs:1486:52:
called `Result::unwrap()` on an `Err` value: TypeParsingError("Unknown data type: b`")

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 42 filtered out; finished in 0.01s
```

The integration test, against a real server (26.7.3.19), reproduces the panic itself:

```
$ cargo test --test it insert_with_json_hint_and_quoted_paths

running 1 test
test insert::insert_with_json_hint_and_quoted_paths ... FAILED

---- insert::insert_with_json_hint_and_quoted_paths stdout ----
Created database chrs__insert__insert_with_json_hint_and_quoted_paths

thread 'insert::insert_with_json_hint_and_quoted_paths' panicked at types/src/data_types.rs:723:51:
index out of bounds: the len is 1 but the index is 1

test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 192 filtered out; finished in 0.04s
```

Both pass with the fix, and the rest of the suite is unaffected:

```
$ cargo test -p clickhouse-types --lib
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s

$ cargo test --workspace           # docker compose up -d
test result: ok. 71 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 188 passed; 0 failed; 5 ignored; 0 measured; 0 filtered out
test result: ok. 8 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
test result: ok. 43 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
```

`cargo fmt -- --check` and `cargo clippy --all-targets --no-default-features` are clean with `RUSTFLAGS=-Dwarnings`.

## Checklist
- [x] Unit and integration tests covering the common scenarios were added
- [x] A human-readable description of the changes was provided so that we can include it in CHANGELOG later

Suggested CHANGELOG entry (Fixed): `JSON` columns whose typed paths are back-quoted, e.g. ``JSON(`a b` Int64)`` or ``JSON(`a,b` Int64)``, no longer fail to parse; the comma case previously panicked with an index out of bounds. ([#453])
