### PR TITLE
Create raw_query to avoid query sustitutions on client side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 * `Client::with_url()` now recognizes the `database` query parameter of the URL. Added `Client::database()` to read back the configured default database. ([#448])
+* Added `Client::query_raw()`, which sends the SQL to the server verbatim, without parsing
+  client-side bind parameters: `?` is not treated as a placeholder, `??` is not unescaped,
+  and `?fields` is not substituted. Server-side parameters via `Query::param()` still work.
+  ([adbc_clickhouse#53])
 
 [#448]: https://github.com/ClickHouse/clickhouse-rs/issues/448
+[adbc_clickhouse#53]: https://github.com/ClickHouse/adbc_clickhouse/issues/53
 
 ## [0.15.1] - 2026-06-01
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ async fn example(client: clickhouse::Client) -> clickhouse::error::Result<()> {
 * Placeholder `?` is replaced with values in following `bind()` calls.
 * Convenient `fetch_one::<Row>()` and `fetch_all::<Row>()` can be used to get a first row or all rows correspondingly.
 * `sql::Identifier` can be used to bind table names.
+* Use `client.query_raw(..)` to send SQL to the server as-is, without any placeholder parsing: `?` is not treated as a placeholder, `??` is not unescaped, and `?fields` is not substituted. To parameterize such queries, use server-side parameters (`{name: type}`) via `.param(..)`.
 
 Note that cursors can return an error even after producing some rows. To avoid this, use `client.with_setting("wait_end_of_query", "1")` in order to enable buffering on the server-side. [More details](https://clickhouse.com/docs/en/interfaces/http/#response-buffering). The `buffer_size` setting can be useful too.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -563,6 +563,40 @@ impl Client {
         query::Query::new(self, query)
     }
 
+    /// Starts a new SELECT/DDL query, sending the provided SQL to the server
+    /// verbatim, without parsing client-side bind parameters.
+    ///
+    /// Unlike [`Client::query()`]:
+    /// * `?` is not treated as a bind placeholder and is sent as-is,
+    ///   so [`Query::bind()`] must not be used with such queries;
+    ///   any call to it will result in an [`error::Error::InvalidParams`]
+    ///   during query execution (`execute()`, `fetch()`, etc.).
+    /// * `??` is not unescaped to `?`.
+    /// * `?fields` is not substituted with the [`Row`] column names.
+    ///
+    /// To parameterize a raw query, use server-side parameters instead:
+    /// reference them as `{name: type}` in the SQL and supply values
+    /// via [`Query::param()`].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// # async fn example() -> clickhouse::error::Result<()> {
+    /// let value: String = clickhouse::Client::default()
+    ///     .query_raw("SELECT concat('foo?', {suffix: String})")
+    ///     .param("suffix", "bar")
+    ///     .fetch_one()
+    ///     .await?;
+    /// assert_eq!(value, "foo?bar");
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`Query::bind()`]: query::Query::bind
+    /// [`Query::param()`]: query::Query::param
+    pub fn query_raw(&self, query: &str) -> query::Query {
+        query::Query::raw(self, query)
+    }
+
     /// Enables or disables [`Row`] data types validation against the database schema
     /// at the cost of performance. Validation is enabled by default, and in this mode,
     /// the client will use `RowBinaryWithNamesAndTypes` format.

--- a/src/query.rs
+++ b/src/query.rs
@@ -34,6 +34,13 @@ impl Query {
         }
     }
 
+    pub(crate) fn raw(client: &Client, query: &str) -> Self {
+        Self {
+            client: client.clone(),
+            sql: SqlBuilder::raw(query),
+        }
+    }
+
     /// Display SQL query as string.
     pub fn sql_display(&self) -> &impl Display {
         &self.sql

--- a/src/sql/mod.rs
+++ b/src/sql/mod.rs
@@ -14,6 +14,7 @@ pub(crate) mod ser;
 #[derive(Debug, Clone)]
 pub(crate) enum SqlBuilder {
     InProgress(Vec<Part>),
+    Raw(String),
     Failed(String),
 }
 
@@ -37,6 +38,7 @@ impl fmt::Display for SqlBuilder {
                     }
                 }
             }
+            SqlBuilder::Raw(query) => f.write_str(query)?,
             SqlBuilder::Failed(err) => f.write_str(err)?,
         }
         Ok(())
@@ -44,6 +46,12 @@ impl fmt::Display for SqlBuilder {
 }
 
 impl SqlBuilder {
+    /// Creates a builder that keeps the query as-is, without parsing `?`
+    /// as bind placeholders. `??` and `?fields` are also left verbatim.
+    pub(crate) fn raw(query: &str) -> Self {
+        SqlBuilder::Raw(query.to_string())
+    }
+
     pub(crate) fn new(template: &str) -> Self {
         let mut parts = Vec::new();
         let mut rest = template;
@@ -73,8 +81,16 @@ impl SqlBuilder {
     }
 
     pub(crate) fn bind_arg(&mut self, value: impl Bind) {
-        let Self::InProgress(parts) = self else {
-            return;
+        let parts = match self {
+            Self::InProgress(parts) => parts,
+            Self::Raw(_) => {
+                return self.error(
+                    "bind() is not supported for raw queries, \
+                     use server-side parameters via param() \
+                     or client-side binding via query() instead",
+                );
+            }
+            _ => return,
         };
 
         if let Some(part) = parts.iter_mut().find(|p| matches!(p, Part::Arg)) {
@@ -127,6 +143,7 @@ impl SqlBuilder {
 
                 Ok(sql)
             }
+            Self::Raw(query) => Ok(query),
             Self::Failed(err) => Err(Error::InvalidParams(err.into())),
         }
     }
@@ -247,6 +264,33 @@ mod tests {
         let mut sql = SqlBuilder::new("SELECT 1 FROM test WHERE a = ?");
         sql.bind_arg(Some(1u32));
         assert_eq!(sql.finish().unwrap(), r"SELECT 1 FROM test WHERE a = 1");
+    }
+
+    #[test]
+    fn raw_keeps_query_verbatim() {
+        const QUERY: &str = "SELECT ?fields FROM test WHERE a = '?' AND b = '??'";
+
+        let sql = SqlBuilder::raw(QUERY);
+        assert_eq!(sql.to_string(), QUERY);
+        assert_eq!(sql.finish().unwrap(), QUERY);
+    }
+
+    #[test]
+    fn raw_rejects_bind() {
+        let mut sql = SqlBuilder::raw("SELECT 1 FROM test WHERE a = ?");
+        sql.bind_arg(42);
+        let err = sql.finish().unwrap_err();
+        assert!(
+            err.to_string()
+                .contains("bind() is not supported for raw queries")
+        );
+    }
+
+    #[test]
+    fn raw_ignores_bind_fields() {
+        let mut sql = SqlBuilder::raw("SELECT a, b FROM test");
+        sql.bind_fields::<Row>();
+        assert_eq!(sql.finish().unwrap(), "SELECT a, b FROM test");
     }
 
     #[test]

--- a/tests/it/main.rs
+++ b/tests/it/main.rs
@@ -270,6 +270,7 @@ mod nested;
 #[cfg(feature = "opentelemetry")]
 mod opentelemetry;
 mod query;
+mod query_raw;
 mod query_readonly;
 mod query_summary;
 mod query_syntax;

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -284,57 +284,6 @@ async fn prints_query() {
     );
 }
 
-// See https://github.com/ClickHouse/adbc_clickhouse/issues/53.
-#[tokio::test]
-async fn raw_query() {
-    let client = prepare_database!();
-
-    #[derive(Debug, Row, Deserialize)]
-    struct MyRow {
-        s: String,
-        n: u8,
-    }
-
-    // `?` is not treated as a bind placeholder.
-    let row = client
-        .query_raw("SELECT 'a?b' AS s, 1 AS n")
-        .fetch_one::<MyRow>()
-        .await
-        .unwrap();
-    assert_eq!(row.s, "a?b");
-    assert_eq!(row.n, 1);
-
-    // `??` is not unescaped to `?`.
-    let value = client
-        .query_raw("SELECT 'a??b'")
-        .fetch_one::<String>()
-        .await
-        .unwrap();
-    assert_eq!(value, "a??b");
-
-    // `bind()` is rejected in raw mode.
-    let err = client
-        .query_raw("SELECT ?")
-        .bind(42)
-        .execute()
-        .await
-        .unwrap_err();
-    assert!(matches!(err, Error::InvalidParams(_)));
-}
-
-#[tokio::test]
-async fn raw_query_with_server_side_param() {
-    let client = prepare_database!();
-
-    let value = client
-        .query_raw("SELECT concat('foo?', {suffix: String}) AS result")
-        .param("suffix", "bar")
-        .fetch_one::<String>()
-        .await
-        .unwrap();
-    assert_eq!(value, "foo?bar");
-}
-
 #[tokio::test]
 async fn query_with_role() {
     let db_name = test_database_name!();

--- a/tests/it/query.rs
+++ b/tests/it/query.rs
@@ -284,6 +284,57 @@ async fn prints_query() {
     );
 }
 
+// See https://github.com/ClickHouse/adbc_clickhouse/issues/53.
+#[tokio::test]
+async fn raw_query() {
+    let client = prepare_database!();
+
+    #[derive(Debug, Row, Deserialize)]
+    struct MyRow {
+        s: String,
+        n: u8,
+    }
+
+    // `?` is not treated as a bind placeholder.
+    let row = client
+        .query_raw("SELECT 'a?b' AS s, 1 AS n")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+    assert_eq!(row.s, "a?b");
+    assert_eq!(row.n, 1);
+
+    // `??` is not unescaped to `?`.
+    let value = client
+        .query_raw("SELECT 'a??b'")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "a??b");
+
+    // `bind()` is rejected in raw mode.
+    let err = client
+        .query_raw("SELECT ?")
+        .bind(42)
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::InvalidParams(_)));
+}
+
+#[tokio::test]
+async fn raw_query_with_server_side_param() {
+    let client = prepare_database!();
+
+    let value = client
+        .query_raw("SELECT concat('foo?', {suffix: String}) AS result")
+        .param("suffix", "bar")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "foo?bar");
+}
+
 #[tokio::test]
 async fn query_with_role() {
     let db_name = test_database_name!();

--- a/tests/it/query_raw.rs
+++ b/tests/it/query_raw.rs
@@ -1,0 +1,111 @@
+//! Tests for `Client::query_raw()`, which sends SQL to the server verbatim,
+//! without client-side bind parameter parsing.
+//!
+//! See https://github.com/ClickHouse/adbc_clickhouse/issues/53.
+
+use serde::Deserialize;
+
+use clickhouse::{Row, error::Error};
+
+use crate::{flush_query_log, get_client};
+
+#[tokio::test]
+async fn keeps_question_marks_verbatim() {
+    let client = get_client();
+
+    #[derive(Debug, Row, Deserialize)]
+    struct MyRow {
+        s: String,
+        n: u8,
+    }
+
+    // `?` is not treated as a bind placeholder.
+    let row = client
+        .query_raw("SELECT 'a?b' AS s, 1 AS n")
+        .fetch_one::<MyRow>()
+        .await
+        .unwrap();
+    assert_eq!(row.s, "a?b");
+    assert_eq!(row.n, 1);
+
+    // `??` is not unescaped to `?`.
+    let value = client
+        .query_raw("SELECT 'a??b'")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "a??b");
+}
+
+#[tokio::test]
+async fn question_marks_in_comments() {
+    let client = get_client();
+
+    let value = client
+        .query_raw("SELECT 1 /* What? How?? Why??? */ WHERE 1 = 1")
+        .fetch_one::<u8>()
+        .await
+        .unwrap();
+    assert_eq!(value, 1);
+}
+
+#[tokio::test]
+async fn rejects_bind() {
+    let client = get_client();
+
+    let err = client
+        .query_raw("SELECT ?")
+        .bind(42)
+        .execute()
+        .await
+        .unwrap_err();
+    assert!(matches!(err, Error::InvalidParams(_)));
+    assert!(
+        err.to_string()
+            .contains("bind() is not supported for raw queries")
+    );
+}
+
+#[tokio::test]
+async fn with_server_side_param() {
+    let client = get_client();
+
+    let value = client
+        .query_raw("SELECT concat('foo?', {suffix: String}) AS result")
+        .param("suffix", "bar")
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "foo?bar");
+}
+
+/// Checks via `system.query_log` that the server received
+/// exactly the SQL that was passed to `query_raw()`.
+#[tokio::test]
+async fn sql_arrives_verbatim() {
+    let client = get_client();
+    let query_id = uuid::Uuid::new_v4().to_string();
+
+    const SQL: &str = "SELECT 'a?b' /* What? How?? Why??? */ AS s";
+
+    let value = client
+        .query_raw(SQL)
+        .with_setting("query_id", &query_id)
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(value, "a?b");
+
+    flush_query_log(&client).await;
+
+    let logged = client
+        .query(
+            "SELECT query FROM system.query_log \
+             WHERE query_id = ? AND type = 'QueryFinish'",
+        )
+        .bind(&query_id)
+        .fetch_one::<String>()
+        .await
+        .unwrap();
+    assert_eq!(logged, SQL);
+}


### PR DESCRIPTION
## Summary

Doing this to unblock the usage of `clickhouse-rs` in ADBC, where it's not required to substitute the `?`. We have many queries with ? as a regular part of the SQL and it was being problematic.

Fixes https://github.com/ClickHouse/clickhouse-rs/issues/234
Related to https://github.com/ClickHouse/clickhouse-rs/issues/157
Related to https://github.com/ClickHouse/adbc_clickhouse/issues/53

Builds on top of https://github.com/ClickHouse/clickhouse-rs/pull/243 as prior art. It contains the changes requested in the review

#### What

`query()` treats every `?` as a bind placeholder, turns `??` into `?`, and replaces `?fields`. Drivers like `adbc_clickhouse` don't use client-side binding, so a literal `?` (e.g. in a regex) breaks their queries.

`query_raw()` returns the same `Query` type, but sends the SQL to the server byte-for-byte. `.bind()` on it fails with a clear error; server-side parameters (`{name: Type}` + `.param()`) still work. Internally this is a new `SqlBuilder::Raw` variant.

This matches clickhouse-go, which sends the query verbatim when no bind args are given.

#### Before / after

```rust
// Regex with `?` quantifiers (dbt-clickhouse had to escape these as \x3F):
let sql = r"select replaceRegexpOne(create_table_query, '.*TO\s+`?(\w+)`?.*', '\1') from system.tables where name = 'my_mv'";

client.query(sql).fetch_one::<String>().await;
// Error: invalid SQL: unbound query argument

client.query_raw(sql).fetch_one::<String>().await?;
// works, sent as-is
```

#### Future compatibility

Purely additive: `query()` is unchanged. If client-side binding is deprecated later (as clickhouse-go already did), `query()` can become raw-by-default at the next major version and `query_raw()` folds away. We can't copy Go's implicit "no args = verbatim" rule today, because `?fields` and `??` are handled without any `bind()` call.

## Checklist
Delete items not relevant to your PR:
- [X] Unit and integration tests covering the common scenarios were added
- [X] A human-readable description of the changes was provided so that we can include it in CHANGELOG later
- [X] For significant changes, documentation in README and https://github.com/ClickHouse/clickhouse-docs was updated with further explanations or tutorials
