### PR TITLE
fix(native): force revision 0 for fetch_native

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -774,6 +774,7 @@ mod formats {
 mod settings {
     pub(crate) const DATABASE: &str = "database";
     pub(crate) const DEFAULT_FORMAT: &str = "default_format";
+    pub(crate) const CLIENT_PROTOCOL_VERSION: &str = "client_protocol_version";
     pub(crate) const COMPRESS: &str = "compress";
     pub(crate) const DECOMPRESS: &str = "decompress";
     #[cfg(feature = "zstd")]

--- a/src/query.rs
+++ b/src/query.rs
@@ -183,6 +183,10 @@ impl Query {
         let span = self.make_span(Some("Native")).entered();
 
         // FIXME: use HTTP body compression instead of block-level compression
+        let _ = self
+            .client
+            .settings
+            .remove(settings::CLIENT_PROTOCOL_VERSION);
         self.client = self.client.with_compression(Compression::None);
 
         let response = self.do_execute(Some("Native"))?;

--- a/tests/it/fetch_native.rs
+++ b/tests/it/fetch_native.rs
@@ -4,6 +4,28 @@ use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 
 #[tokio::test]
+async fn fetch_native_overrides_client_protocol_version() {
+    let client = get_client().with_setting("client_protocol_version", "1");
+
+    let mut cursor = client
+        .query("SELECT toUInt64(42) AS value")
+        .fetch_native()
+        .unwrap();
+
+    let block = cursor.next().await.unwrap().unwrap();
+    assert_eq!(
+        block["value"]
+            .iter::<u64>()
+            .unwrap()
+            .next()
+            .unwrap()
+            .unwrap(),
+        42
+    );
+    assert!(cursor.next().await.unwrap().is_none());
+}
+
+#[tokio::test]
 async fn mixed_types_empty() {
     mixed_types(0).await
 }


### PR DESCRIPTION
## Summary

- **Problem:** `fetch_native()` uses the Native format, but `NativeCursor` currently supports only revision `0`.
- If a client has `client_protocol_version` set above `0`, ClickHouse adds `BlockInfo` to the response. The cursor then reads the response with the wrong layout.
- **Fix:** remove `client_protocol_version` from the query-local settings before `fetch_native()` runs. ClickHouse then uses revision `0` for that request.
- The original `Client` is unchanged, and other query formats keep their existing setting.
- This avoids adding a new setting and allocating new key/value strings on every native fetch.

## Tests

- Added an integration test with `client_protocol_version=1`.
- `cargo fmt -- --check`
- `CARGO_INCREMENTAL=0 cargo check --test it --no-default-features`

## Checklist

- [x] Integration test added
- [x] Human-readable description included
- [x] Documentation changes are not needed for this compatibility fix